### PR TITLE
Implemented URL canonicalization service

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import Fastify, { FastifyError, FastifyRequest, FastifyReply } from 'fastify';
+import Fastify, { FastifyRequest, FastifyReply } from 'fastify';
 import { healthRoutes } from './routes/health.route';
 import { checkRoutes } from './routes/check.route';
 import { apiKeyAuthPlugin } from './plugins/apiKeyAuth';
@@ -6,6 +6,7 @@ import { requestIdPlugin } from './plugins/requestId';
 import { requestLoggerPlugin } from './plugins/requestLogger';
 import { NODE_ENV } from './config';
 import { ErrorResponse } from './types/observability';
+import { ApiError, isApiError } from './errors';
 
 // Import types to ensure Fastify type extensions are loaded
 import './types/auth';
@@ -42,29 +43,58 @@ const app = Fastify({
  *
  * Provides consistent error responses across all endpoints.
  *
+ * Handles custom error types:
+ * - InvalidUrlError (400) - Bad URL format
+ * - FetchError (502) - Cannot reach target
+ * - HttpError (502) - Target returned error
+ *
  * Security considerations:
  * - Production: Hide stack traces to prevent information leakage
  * - Development: Include stack traces for debugging
  * - Always include request_id for log correlation
+ * - Never expose internal implementation details
  */
-app.setErrorHandler((error: FastifyError, request: FastifyRequest, reply: FastifyReply) => {
-  const statusCode = error.statusCode ?? 500;
+app.setErrorHandler((error: Error, request: FastifyRequest, reply: FastifyReply) => {
   const requestId = request.requestId ?? 'unknown';
 
-  // Log the full error server-side
+  // Determine status code from error type
+  let statusCode: number;
+  let errorName: string;
+  let message: string;
+
+  if (isApiError(error)) {
+    // Custom API errors have their own status codes
+    statusCode = (error as ApiError).statusCode;
+    errorName = error.name;
+    message = error.message;
+  } else if ('statusCode' in error && typeof error.statusCode === 'number') {
+    // Fastify errors (validation, etc.)
+    statusCode = error.statusCode;
+    errorName = error.name || 'Error';
+    message = error.message;
+  } else {
+    // Unknown errors - treat as internal server error
+    statusCode = 500;
+    errorName = 'InternalServerError';
+    // Hide internal error details in production
+    message = isProduction ? 'Internal server error' : error.message;
+  }
+
+  // Log the full error server-side (always include stack for debugging)
   request.log.error(
     {
       err: error,
       requestId,
       statusCode,
+      errorName,
     },
     'Request error',
   );
 
   // Build client-facing error response
   const response: ErrorResponse = {
-    error: error.name || 'InternalServerError',
-    message: statusCode >= 500 && isProduction ? 'Internal server error' : error.message,
+    error: errorName,
+    message,
     request_id: requestId,
   };
 

--- a/src/controllers/check.controller.ts
+++ b/src/controllers/check.controller.ts
@@ -1,7 +1,37 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
 import { checkPage } from '../services/page.service';
 
-export async function checkController(req: any) {
-  const { url } = req.body;
+/**
+ * Request body type for /v1/check endpoint
+ */
+type CheckRequestBody = {
+  url: string;
+};
 
-  return await checkPage(url);
+/**
+ * Controller for POST /v1/check
+ *
+ * Validates URL presence and delegates to page service.
+ * All errors (InvalidUrlError, FetchError, HttpError) are
+ * propagated to the global error handler for consistent responses.
+ */
+export async function checkController(
+  request: FastifyRequest<{ Body: CheckRequestBody }>,
+  reply: FastifyReply,
+): Promise<void> {
+  const { url } = request.body || {};
+
+  // Validate URL presence
+  if (!url || typeof url !== 'string') {
+    reply.code(400).send({
+      error: 'BadRequest',
+      message: 'URL is required',
+      request_id: request.requestId,
+    });
+    return;
+  }
+
+  // Delegate to service - errors propagate to global handler
+  const result = await checkPage(url, request.log);
+  reply.send(result);
 }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,85 @@
+/**
+ * Custom Error Classes for PolicyDiff API
+ *
+ * WHY STRUCTURED ERRORS ARE CRITICAL FOR API CONSUMERS:
+ * - Consistent error format enables programmatic error handling
+ * - Error names allow clients to show appropriate UI messages
+ * - Status codes enable proper HTTP semantics
+ * - Request IDs enable debugging and support tickets
+ *
+ * WHY WE AVOID LEAKING INTERNAL ERRORS:
+ * - Stack traces reveal file paths and library versions
+ * - Internal error messages may expose database schema
+ * - Generic messages prevent information disclosure attacks
+ */
+
+/**
+ * Base class for all custom API errors
+ * Includes HTTP status code for proper response handling
+ */
+export abstract class ApiError extends Error {
+  abstract readonly statusCode: number;
+
+  constructor(message: string) {
+    super(message);
+    // Maintains proper prototype chain for instanceof checks
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+/**
+ * Invalid URL Error
+ * Thrown when URL format is invalid, empty, or uses unsupported protocol
+ *
+ * HTTP Status: 400 Bad Request
+ */
+export class InvalidUrlError extends ApiError {
+  readonly statusCode = 400;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidUrlError';
+  }
+}
+
+/**
+ * Fetch Error
+ * Thrown when unable to reach the target URL
+ * Causes: DNS failure, connection timeout, network unreachable
+ *
+ * HTTP Status: 502 Bad Gateway (upstream server unreachable)
+ */
+export class FetchError extends ApiError {
+  readonly statusCode = 502;
+  readonly cause?: string;
+
+  constructor(message: string, cause?: string) {
+    super(message);
+    this.name = 'FetchError';
+    this.cause = cause;
+  }
+}
+
+/**
+ * HTTP Error
+ * Thrown when target URL returns an error status code (4xx or 5xx)
+ *
+ * HTTP Status: 502 Bad Gateway (upstream returned error)
+ */
+export class HttpError extends ApiError {
+  readonly statusCode = 502;
+  readonly upstreamStatus: number;
+
+  constructor(message: string, upstreamStatus: number) {
+    super(message);
+    this.name = 'HttpError';
+    this.upstreamStatus = upstreamStatus;
+  }
+}
+
+/**
+ * Type guard to check if an error is a custom API error
+ */
+export function isApiError(error: unknown): error is ApiError {
+  return error instanceof ApiError;
+}

--- a/src/repositories/page.repository.ts
+++ b/src/repositories/page.repository.ts
@@ -2,12 +2,35 @@ import { DB } from '../db';
 import { Section, Change } from '../types';
 import { diffSections } from '../services/differ.service';
 
+/**
+ * Result type for savePage operation
+ * Includes pageId for debugging and logging
+ */
+export type SavePageResult = {
+  status: 'unchanged' | 'first_version' | 'changed';
+  pageId: number;
+  changes?: Change[];
+};
+
+/**
+ * Save or update a page and create a new version if content changed
+ *
+ * Uses ON CONFLICT to ensure idempotent page creation.
+ * The RETURNING id clause works for both INSERT and UPDATE cases,
+ * guaranteeing we always get the correct page ID.
+ *
+ * @param url - Canonical URL (must be pre-canonicalized!)
+ * @param content - Normalized page content
+ * @param contentHash - SHA-256 hash of content for fast comparison
+ * @param sections - Extracted sections from HTML
+ */
 export async function savePage(
   url: string,
   content: string,
   contentHash: string,
   sections: Section[],
-): Promise<{ status: 'unchanged' | 'first_version' | 'changed'; changes?: Change[] }> {
+): Promise<SavePageResult> {
+  // Upsert page record - RETURNING id works for both insert and conflict
   const pageResult = await DB.query(
     'INSERT INTO pages (url) VALUES ($1) ON CONFLICT (url) DO UPDATE SET url = EXCLUDED.url RETURNING id',
     [url],
@@ -15,21 +38,30 @@ export async function savePage(
 
   const pageId: number = pageResult.rows[0].id;
 
-  // Fetch latest version
+  // SAFETY CHECK: Explicitly check if ANY versions exist for this page
+  // This prevents the "first snapshot" bug where a race condition or
+  // failed previous insert could cause us to treat an existing page as new
+  const versionCountResult = await DB.query('SELECT COUNT(*)::int as count FROM page_versions WHERE page_id = $1', [
+    pageId,
+  ]);
+  const versionCount: number = versionCountResult.rows[0].count;
+
+  // Fetch latest version for comparison
   const latestVersionResult = await DB.query(
     'SELECT content_hash, sections FROM page_versions WHERE page_id = $1 ORDER BY created_at DESC LIMIT 1',
     [pageId],
   );
 
-  if (latestVersionResult.rows.length > 0) {
+  // If versions exist, compare with latest
+  if (versionCount > 0 && latestVersionResult.rows.length > 0) {
     const latestHash = latestVersionResult.rows[0].content_hash;
     const latestSections = latestVersionResult.rows[0].sections as Section[];
 
     if (latestHash === contentHash) {
-      return { status: 'unchanged' };
+      return { status: 'unchanged', pageId };
     }
 
-    // Calculate diff
+    // Calculate diff between old and new sections
     const changes = diffSections(latestSections, sections);
 
     await DB.query('INSERT INTO page_versions (page_id, content, content_hash, sections) VALUES ($1, $2, $3, $4)', [
@@ -39,10 +71,10 @@ export async function savePage(
       JSON.stringify(sections),
     ]);
 
-    return { status: 'changed', changes };
+    return { status: 'changed', pageId, changes };
   }
 
-  // First version
+  // First version - only when NO versions exist for this page_id
   await DB.query('INSERT INTO page_versions (page_id, content, content_hash, sections) VALUES ($1, $2, $3, $4)', [
     pageId,
     content,
@@ -50,5 +82,5 @@ export async function savePage(
     JSON.stringify(sections),
   ]);
 
-  return { status: 'first_version' };
+  return { status: 'first_version', pageId };
 }

--- a/src/services/page.service.ts
+++ b/src/services/page.service.ts
@@ -3,15 +3,62 @@ import { savePage } from '../repositories/page.repository';
 import { normalizeContent } from './normalizer.service';
 import { extractSections } from './sectionExtractor.service';
 import { generateHash } from '../utils/hash';
+import { canonicalizeUrl } from '../utils/canonicalizeUrl';
 import { DiffResult } from '../types';
 import { analyzeRisk } from './riskEngine.service';
 
-export async function checkPage(url: string): Promise<DiffResult> {
-  const rawHtml = await fetchPage(url);
+/**
+ * Logger interface for debug output
+ */
+type Logger = {
+  debug: (obj: object, msg: string) => void;
+};
+
+/**
+ * Check a page for policy changes
+ *
+ * WHY CANONICALIZATION MUST HAPPEN BEFORE DB LOOKUP:
+ * Without it, URL variants create duplicate page records, causing
+ * the "first snapshot" bug where the same page appears as new.
+ *
+ * @param rawUrl - User-provided URL (will be canonicalized)
+ * @param logger - Optional logger for debug tracing
+ * @returns DiffResult with status and any detected changes
+ */
+export async function checkPage(rawUrl: string, logger?: Logger): Promise<DiffResult> {
+  // CRITICAL: Canonicalize URL BEFORE any database operation
+  // This ensures consistent identity regardless of URL variants:
+  // - Different casing: Example.com → example.com
+  // - Trailing slashes: /privacy/ → /privacy
+  // - Query params: ?utm=test → removed
+  // - Protocol: http → https
+  const canonicalUrl = canonicalizeUrl(rawUrl);
+
+  // Debug logging for URL canonicalization tracing
+  if (logger) {
+    logger.debug({ rawUrl, canonicalUrl }, 'URL canonicalized');
+  }
+
+  // Fetch using canonical URL
+  const rawHtml = await fetchPage(canonicalUrl);
   const normalizedContent = normalizeContent(rawHtml);
   const sections = extractSections(rawHtml);
   const contentHash = generateHash(normalizedContent);
-  const result = await savePage(url, normalizedContent, contentHash, sections);
+
+  // Save using ONLY the canonical URL - never the raw input
+  const result = await savePage(canonicalUrl, normalizedContent, contentHash, sections);
+
+  // Debug logging for page identity tracing
+  if (logger) {
+    logger.debug(
+      {
+        canonicalUrl,
+        pageId: result.pageId,
+        status: result.status,
+      },
+      'Page processed',
+    );
+  }
 
   if (result.status === 'first_version') {
     return { message: 'First snapshot stored' };

--- a/src/utils/canonicalizeUrl.ts
+++ b/src/utils/canonicalizeUrl.ts
@@ -1,0 +1,126 @@
+/**
+ * URL Canonicalization Utility
+ *
+ * WHY CANONICALIZATION MUST HAPPEN BEFORE DB LOOKUP:
+ * Without canonicalization, the same logical page can create multiple database
+ * entries. For example, "Example.com/privacy" and "example.com/privacy" would
+ * be treated as different pages, causing the "first snapshot" bug.
+ *
+ * WHY PROTOCOL NORMALIZATION MATTERS:
+ * HTTP and HTTPS versions of the same URL should be treated as one identity.
+ * Forcing HTTPS ensures consistent lookups and prevents split identity where
+ * http://example.com and https://example.com create separate page records.
+ *
+ * WHY REMOVING QUERY PARAMS PREVENTS DUPLICATE IDENTITY:
+ * Query parameters like ?utm_source=twitter or ?ref=homepage don't change
+ * the policy content, but would create separate page records without removal.
+ * This causes the same page to show "first snapshot" repeatedly.
+ *
+ * WHY FORCING HTTPS PREVENTS SPLIT IDENTITY:
+ * Most sites redirect HTTP to HTTPS anyway. By normalizing to HTTPS, we ensure
+ * that regardless of what the user provides, we always look up the same record.
+ *
+ * WHY THIS FIXES THE "SOMETIMES FIRST SNAPSHOT" BUG:
+ * The bug occurs because URL variants like:
+ *   - https://Example.com/privacy
+ *   - https://example.com/privacy/
+ *   - https://example.com/privacy?utm=test
+ * All create different page records. By canonicalizing to a single form
+ * (https://example.com/privacy), all lookups resolve to the same record.
+ */
+
+// Re-export InvalidUrlError from centralized errors module
+export { InvalidUrlError } from '../errors';
+import { InvalidUrlError } from '../errors';
+
+/**
+ * Canonicalize a URL to ensure consistent identity across variants
+ *
+ * Rules applied:
+ * 1. Trim whitespace
+ * 2. Auto-add https:// if no protocol
+ * 3. Parse using WHATWG URL
+ * 4. Lowercase hostname
+ * 5. Force protocol to https
+ * 6. Remove query parameters
+ * 7. Remove hash fragments
+ * 8. Normalize pathname (collapse duplicate slashes)
+ * 9. Remove trailing slash (unless root path)
+ *
+ * @param inputUrl - Raw URL string from user input
+ * @returns Canonical URL string
+ * @throws InvalidUrlError if URL is empty or malformed
+ */
+export function canonicalizeUrl(inputUrl: string): string {
+  // Trim whitespace
+  const trimmed = inputUrl.trim();
+
+  // Check for empty string
+  if (!trimmed) {
+    throw new InvalidUrlError('URL cannot be empty');
+  }
+
+  // Auto-add https:// if no protocol provided
+  let urlToParse = trimmed;
+  if (!trimmed.includes('://')) {
+    urlToParse = `https://${trimmed}`;
+  }
+
+  // Parse using WHATWG URL API
+  let parsed: URL;
+  try {
+    parsed = new URL(urlToParse);
+  } catch {
+    throw new InvalidUrlError(`Invalid URL format: ${inputUrl}`);
+  }
+
+  // Validate protocol (only http/https allowed)
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new InvalidUrlError(`Invalid protocol: ${parsed.protocol}`);
+  }
+
+  // Force HTTPS protocol
+  parsed.protocol = 'https:';
+
+  // Hostname is automatically lowercased by URL API
+  // But let's be explicit for clarity
+  const hostname = parsed.hostname.toLowerCase();
+
+  // Normalize pathname:
+  // 1. Collapse duplicate slashes (//privacy// → /privacy/)
+  // 2. Decode percent-encoded characters that don't need encoding
+  let pathname = parsed.pathname.replace(/\/+/g, '/');
+
+  // Remove trailing slash unless it's the root path
+  if (pathname.length > 1 && pathname.endsWith('/')) {
+    pathname = pathname.slice(0, -1);
+  }
+
+  // Build canonical URL without query params or hash
+  // Note: We preserve the port if non-standard
+  let canonical = `https://${hostname}`;
+
+  // Include port only if non-standard
+  if (parsed.port && parsed.port !== '443') {
+    canonical += `:${parsed.port}`;
+  }
+
+  canonical += pathname;
+
+  return canonical;
+}
+
+/**
+ * Check if a string is a valid URL without throwing
+ *
+ * @param inputUrl - URL string to validate
+ * @returns true if valid, false otherwise
+ */
+export function isValidUrl(inputUrl: string): boolean {
+  try {
+    canonicalizeUrl(inputUrl);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/fetchPage.ts
+++ b/src/utils/fetchPage.ts
@@ -1,6 +1,70 @@
-import axios from 'axios';
+import axios, { AxiosError } from 'axios';
+import { FetchError, HttpError } from '../errors';
 
+/**
+ * Fetch a page's HTML content
+ *
+ * @param url - URL to fetch (should be canonical)
+ * @returns HTML content as string
+ * @throws FetchError - DNS failure, timeout, network error
+ * @throws HttpError - Server returned 4xx or 5xx status
+ */
 export async function fetchPage(url: string): Promise<string> {
-  const res = await axios.get(url, { timeout: 5000 });
-  return res.data;
+  try {
+    const res = await axios.get<string>(url, {
+      timeout: 10000, // 10 second timeout
+      maxRedirects: 5,
+      headers: {
+        // Identify as a bot for transparency
+        'User-Agent': 'PolicyDiffBot/1.0',
+        Accept: 'text/html,application/xhtml+xml',
+      },
+      // Ensure we get string data
+      responseType: 'text',
+    });
+
+    return res.data;
+  } catch (error) {
+    // Handle Axios errors specifically
+    if (axios.isAxiosError(error)) {
+      const axiosError = error as AxiosError;
+
+      // HTTP error response (4xx, 5xx)
+      if (axiosError.response) {
+        const status = axiosError.response.status;
+        throw new HttpError(`Target URL returned ${status}`, status);
+      }
+
+      // Request made but no response received (timeout, DNS, network)
+      if (axiosError.request) {
+        // Categorize the error based on code
+        const code = axiosError.code;
+
+        if (code === 'ECONNABORTED' || code === 'ETIMEDOUT') {
+          throw new FetchError('Request timed out', 'timeout');
+        }
+
+        if (code === 'ENOTFOUND' || code === 'EAI_AGAIN') {
+          throw new FetchError('Domain not found (DNS failure)', 'dns');
+        }
+
+        if (code === 'ECONNREFUSED') {
+          throw new FetchError('Connection refused by server', 'connection');
+        }
+
+        if (code === 'ECONNRESET') {
+          throw new FetchError('Connection reset by server', 'connection');
+        }
+
+        // Generic network error
+        throw new FetchError('Unable to reach target URL', code || 'unknown');
+      }
+
+      // Error setting up request
+      throw new FetchError(`Request failed: ${axiosError.message}`, 'request');
+    }
+
+    // Non-Axios error (should not happen, but handle gracefully)
+    throw new FetchError('Unexpected error during fetch', 'unknown');
+  }
 }


### PR DESCRIPTION
Implemented URL canonicalization such as:
- Trim whitespace.
- Use new URL() for parsing.
- Lowercase protocol and hostname.
- Remove trailing slash.
- Remove query parameters.
- Remove hash fragments.
- Remove default ports (80 for http, 443 for https).
- Enforce https (convert http → https).