### PR TITLE
feat(diff-engine): add granular word-level diff details for modified …

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,12 +290,29 @@ Retrieves the status and result of a monitoring job.
         "section": "data sharing with third parties",
         "type": "MODIFIED",
         "risk": "HIGH",
-        "reason": "High risk keyword detected in content"
+        "reason": "High risk keyword detected in content",
+        "details": [
+          { "value": "We may share your data with ", "added": false, "removed": false },
+          { "value": "partners", "added": false, "removed": true },
+          { "value": "unaffiliated third parties", "added": true, "removed": false },
+          { "value": ".", "added": false, "removed": false }
+        ]
       }
     ]
   }
 }
 ```
+
+**Diff Details Structure:**
+
+For `MODIFIED` sections, the `details` field provides a granular word-level diff (Myers algorithm):
+
+- `value`: The text segment.
+- `added`: `true` if the segment was newly inserted.
+- `removed`: `true` if the segment was deleted.
+- If both are `false`, the segment represents unchanged context.
+- They are never both `true`.
+- The output is deterministic and word-based.
 
 **Example Response (Failed):**
 

--- a/docs/async-monitoring.md
+++ b/docs/async-monitoring.md
@@ -143,7 +143,13 @@ X-API-Key: pdiff_xxx
         "section": "Data Sharing",
         "type": "MODIFIED",
         "risk": "HIGH",
-        "reason": "High risk keyword detected in content"
+        "reason": "High risk keyword detected in content",
+        "details": [
+          { "value": "We may share your data with ", "added": false, "removed": false },
+          { "value": "partners", "added": false, "removed": true },
+          { "value": "unaffiliated third parties", "added": true, "removed": false },
+          { "value": ".", "added": false, "removed": false }
+        ]
       }
     ]
   }

--- a/src/services/differ.service.ts
+++ b/src/services/differ.service.ts
@@ -1,5 +1,5 @@
-import { Section, Change } from '../types';
-import { diffWords } from 'diff';
+import { Section, Change, DiffDetail } from '../types';
+import { diffWords, Change as DiffChange } from 'diff';
 
 /**
  * WHY SMALL-CHANGE THRESHOLD REDUCES NOISE:
@@ -29,18 +29,21 @@ function normalizeText(text: string): string {
 }
 
 /**
- * Calculate change ratio between two strings
+ * Calculate change ratio and return diff parts between two strings
  * Uses word-based Myers diff algorithm using diff library.
  * Improves insertion/deletion accuracy and prevents false high ratios from character shifting.
  *
- * @returns Ratio of change (0.0 = identical, 1.0 = completely different)
+ * @returns Object with ratio of change and the diff parts
  */
-function calculateChangeRatio(oldText: string, newText: string): number {
+function calculateChangeRatio(
+  oldText: string,
+  newText: string,
+): { ratio: number; diff: DiffChange[] } {
   const normalizedOld = normalizeText(oldText);
   const normalizedNew = normalizeText(newText);
 
   if (normalizedOld.length === 0) {
-    return 1;
+    return { ratio: 1, diff: [{ value: normalizedNew, added: true, removed: false, count: 1 }] };
   }
 
   const diff = diffWords(normalizedOld, normalizedNew);
@@ -55,15 +58,24 @@ function calculateChangeRatio(oldText: string, newText: string): number {
 
   const ratio = changedCharacters / normalizedOld.length;
 
-  return Math.min(1, ratio);
+  return {
+    ratio: Math.min(1, ratio),
+    diff,
+  };
 }
 
 /**
- * Check if a modification is meaningful based on change threshold
+ * Check if a modification is meaningful and return diff parts if so
  */
-function isMeaningfulChange(oldContent: string, newContent: string): boolean {
-  const ratio = calculateChangeRatio(oldContent, newContent);
-  return ratio >= MEANINGFUL_CHANGE_THRESHOLD;
+function getMeaningfulChange(
+  oldContent: string,
+  newContent: string,
+): { isMeaningful: boolean; diff?: DiffChange[] } {
+  const { ratio, diff } = calculateChangeRatio(oldContent, newContent);
+  if (ratio >= MEANINGFUL_CHANGE_THRESHOLD) {
+    return { isMeaningful: true, diff };
+  }
+  return { isMeaningful: false };
 }
 
 /**
@@ -93,8 +105,20 @@ export function diffSections(oldSections: Section[], newSections: Section[]): Ch
     } else if (oldSection.hash !== newSection.hash) {
       // Hash changed - check if modification is meaningful
       // This filters out minor punctuation/whitespace changes
-      if (isMeaningfulChange(oldSection.content, newSection.content)) {
-        changes.push({ section: newSection.title, type: 'MODIFIED' });
+      const meaningfulChange = getMeaningfulChange(oldSection.content, newSection.content);
+
+      if (meaningfulChange.isMeaningful && meaningfulChange.diff) {
+        const details: DiffDetail[] = meaningfulChange.diff.map((part) => ({
+          value: part.value,
+          added: part.added === true,
+          removed: part.removed === true,
+        }));
+
+        changes.push({
+          section: newSection.title,
+          type: 'MODIFIED',
+          details,
+        });
       }
       // If not meaningful, silently ignore the change
     }

--- a/src/services/riskEngine.service.ts
+++ b/src/services/riskEngine.service.ts
@@ -65,6 +65,7 @@ function evaluateChange(change: Change, newSections: Section[]): RiskedChange {
     type,
     risk,
     reason,
+    details: change.details,
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,9 +11,16 @@ export type Section = {
 
 export type ChangeType = 'ADDED' | 'REMOVED' | 'MODIFIED';
 
+export interface DiffDetail {
+  value: string;
+  added: boolean;
+  removed: boolean;
+}
+
 export type Change = {
   section: string;
   type: ChangeType;
+  details?: DiffDetail[];
 };
 
 export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
@@ -23,6 +30,7 @@ export type RiskedChange = {
   type: ChangeType;
   risk: RiskLevel;
   reason: string;
+  details?: DiffDetail[];
 };
 
 /**


### PR DESCRIPTION
Adds structured word-level diff details for MODIFIED sections using Myers-based diff results.

1. Extends Change type with optional details field
2. Returns structured additions/removals for modified sections
3. No breaking changes to API contract
4. No changes to risk classification
5. No additional database writes
6. Deterministic and performance-safe

Enhances user visibility into what exactly changed while preserving existing behavior.