### PR TITLE
Add fuzzy matching for section titles using Levenshtein similarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The system is built on a foundation of discrete, purposeful features:
 -   **Canonicalized URLs**: Normalizes URLs to prevent duplicate tracking of the same page (e.g., `http://` vs `https://`, trailing slashes, query parameters).
 -   **Section Extraction**: Parses HTML into logical sections using `<h1>`, `<h2>`, and `<h3>` tags as delimiters.
 -   **Section-Level Hashing**: Generates a SHA-256 hash for each section's content, enabling rapid detection of modifications.
--   **Structural Diff Engine**: Identifies changes as `ADDED`, `REMOVED`, or `MODIFIED` at the section level, not just the line level.
+-   **Structural Diff Engine**: Identifies changes as `ADDED`, `REMOVED`, or `MODIFIED` at the section level. Sections are matched using exact title match first. If an exact match fails, deterministic Levenshtein similarity matching is applied with a threshold of 0.85 to prevent minor title edits from being misclassified as `REMOVED` + `ADDED`.
 -   **Meaningful Change Threshold**: Ignores modifications below a certain threshold (e.g., minor punctuation changes) to reduce noise.
 -   **Rule-Based Risk Engine**: Classifies changes using a predefined, deterministic set of keywords and rules.
 -   **Global Risk Aggregation**: Aggregates section-level risks into a single `LOW`, `MEDIUM`, or `HIGH` risk score for the entire document change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "cheerio": "^1.0.0-rc.12",
         "diff": "^8.0.3",
         "dotenv": "^17.2.4",
+        "fast-levenshtein": "^3.0.0",
         "fastify": "^5.7.4",
         "fastify-plugin": "^5.1.0",
         "pg": "^8.18.0"
@@ -20,6 +21,7 @@
       "devDependencies": {
         "@types/cheerio": "^0.22.35",
         "@types/diff": "^7.0.2",
+        "@types/fast-levenshtein": "^0.0.4",
         "@types/node": "^25.2.2",
         "@types/pg": "^8.11.0",
         "@typescript-eslint/eslint-plugin": "^6.13.2",
@@ -410,6 +412,13 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-7.0.2.tgz",
       "integrity": "sha512-JSWRMozjFKsGlEjiiKajUjIJVKuKdE3oVy2DNtK+fUo8q82nhFZ2CPQwicAIkXrofahDXrWJ7mjelvZphMS98Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/fast-levenshtein": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fast-levenshtein/-/fast-levenshtein-0.0.4.tgz",
+      "integrity": "sha512-tkDveuitddQCxut1Db8eEFfMahTjOumTJGPHmT9E7KUH+DkVq9WTpVvlfenf3S+uCBeu8j5FP2xik/KfxOEjeA==",
       "dev": true,
       "license": "MIT"
     },
@@ -1713,11 +1722,13 @@
       }
     },
     "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "license": "MIT"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-3.0.0.tgz",
+      "integrity": "sha512-hKKNajm46uNmTlhHSyZkmToAc56uZJwYq7yrciZjqOxnlfQwERDQJmHPUp7m1m9wx8vgOe8IaCKZ5Kv2k1DdCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "fastest-levenshtein": "^1.0.7"
+      }
     },
     "node_modules/fast-querystring": {
       "version": "1.1.2",
@@ -1750,6 +1761,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastest-levenshtein": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+      "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastify": {
       "version": "5.7.4",
@@ -2648,6 +2668,13 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/optionator/node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@types/cheerio": "^0.22.35",
     "@types/diff": "^7.0.2",
+    "@types/fast-levenshtein": "^0.0.4",
     "@types/node": "^25.2.2",
     "@types/pg": "^8.11.0",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
@@ -35,6 +36,7 @@
     "cheerio": "^1.0.0-rc.12",
     "diff": "^8.0.3",
     "dotenv": "^17.2.4",
+    "fast-levenshtein": "^3.0.0",
     "fastify": "^5.7.4",
     "fastify-plugin": "^5.1.0",
     "pg": "^8.18.0"

--- a/src/routes/batch.route.ts
+++ b/src/routes/batch.route.ts
@@ -31,4 +31,3 @@ export async function batchRoutes(fastify: FastifyInstance) {
     getBatchStatusController,
   );
 }
-

--- a/src/services/differ.service.ts
+++ b/src/services/differ.service.ts
@@ -1,5 +1,6 @@
 import { Section, Change, DiffDetail } from '../types';
 import { diffWords, Change as DiffChange } from 'diff';
+import levenshtein from 'fast-levenshtein';
 
 /**
  * WHY SMALL-CHANGE THRESHOLD REDUCES NOISE:
@@ -11,6 +12,12 @@ import { diffWords, Change as DiffChange } from 'diff';
 
 /** Minimum change ratio to consider a modification meaningful */
 const MEANINGFUL_CHANGE_THRESHOLD = 0.05; // 5%
+
+/**
+ * Threshold for fuzzy title matching to prevent REMOVED + ADDED misclassification
+ * when titles are slightly reworded.
+ */
+const TITLE_SIMILARITY_THRESHOLD = 0.85;
 
 /**
  * Normalize text for comparison
@@ -29,16 +36,36 @@ function normalizeText(text: string): string {
 }
 
 /**
+ * Calculate similarity between two titles using Levenshtein distance
+ *
+ * @returns Similarity score between 0 and 1
+ */
+function calculateTitleSimilarity(a: string, b: string): number {
+  const normalizedA = normalizeText(a);
+  const normalizedB = normalizeText(b);
+
+  if (normalizedA.length === 0 && normalizedB.length === 0) {
+    return 1;
+  }
+
+  const distance = levenshtein.get(normalizedA, normalizedB);
+  const maxLength = Math.max(normalizedA.length, normalizedB.length);
+
+  if (maxLength === 0) {
+    return 1;
+  }
+
+  return 1 - distance / maxLength;
+}
+
+/**
  * Calculate change ratio and return diff parts between two strings
  * Uses word-based Myers diff algorithm using diff library.
  * Improves insertion/deletion accuracy and prevents false high ratios from character shifting.
  *
  * @returns Object with ratio of change and the diff parts
  */
-function calculateChangeRatio(
-  oldText: string,
-  newText: string,
-): { ratio: number; diff: DiffChange[] } {
+function calculateChangeRatio(oldText: string, newText: string): { ratio: number; diff: DiffChange[] } {
   const normalizedOld = normalizeText(oldText);
   const normalizedNew = normalizeText(newText);
 
@@ -67,10 +94,7 @@ function calculateChangeRatio(
 /**
  * Check if a modification is meaningful and return diff parts if so
  */
-function getMeaningfulChange(
-  oldContent: string,
-  newContent: string,
-): { isMeaningful: boolean; diff?: DiffChange[] } {
+function getMeaningfulChange(oldContent: string, newContent: string): { isMeaningful: boolean; diff?: DiffChange[] } {
   const { ratio, diff } = calculateChangeRatio(oldContent, newContent);
   if (ratio >= MEANINGFUL_CHANGE_THRESHOLD) {
     return { isMeaningful: true, diff };
@@ -84,6 +108,9 @@ function getMeaningfulChange(
  * Uses section hashes for fast comparison, then applies
  * meaningful change filter to reduce noise from minor edits.
  *
+ * Implements deterministic fuzzy section title matching to prevent
+ * minor title edits from being classified as REMOVED + ADDED.
+ *
  * @param oldSections - Sections from previous version
  * @param newSections - Sections from current version
  * @returns Array of meaningful changes
@@ -91,45 +118,81 @@ function getMeaningfulChange(
 export function diffSections(oldSections: Section[], newSections: Section[]): Change[] {
   const changes: Change[] = [];
 
-  // Build maps for O(1) lookup using both hash and content
-  const oldMap = new Map(oldSections.map((s) => [s.title, s]));
-  const newMap = new Map(newSections.map((s) => [s.title, s]));
+  // Tracks which old sections are still available for matching
+  const unmatchedOldSections = new Map(oldSections.map((s) => [s.title, s]));
+  const pendingNewSections: Section[] = [];
 
-  // Check for ADDED and MODIFIED
+  // PASS 1: Exact Title Matching
   for (const newSection of newSections) {
-    const oldSection = oldMap.get(newSection.title);
+    const oldSection = unmatchedOldSections.get(newSection.title);
 
-    if (oldSection === undefined) {
-      // Section is completely new
-      changes.push({ section: newSection.title, type: 'ADDED' });
-    } else if (oldSection.hash !== newSection.hash) {
-      // Hash changed - check if modification is meaningful
-      // This filters out minor punctuation/whitespace changes
-      const meaningfulChange = getMeaningfulChange(oldSection.content, newSection.content);
+    if (oldSection) {
+      unmatchedOldSections.delete(newSection.title);
 
-      if (meaningfulChange.isMeaningful && meaningfulChange.diff) {
-        const details: DiffDetail[] = meaningfulChange.diff.map((part) => ({
-          value: part.value,
-          added: part.added === true,
-          removed: part.removed === true,
-        }));
+      if (oldSection.hash !== newSection.hash) {
+        // Hash changed - check if modification is meaningful
+        const meaningfulChange = getMeaningfulChange(oldSection.content, newSection.content);
 
-        changes.push({
-          section: newSection.title,
-          type: 'MODIFIED',
-          details,
-        });
+        if (meaningfulChange.isMeaningful && meaningfulChange.diff) {
+          const details: DiffDetail[] = meaningfulChange.diff.map((part) => ({
+            value: part.value,
+            added: part.added === true,
+            removed: part.removed === true,
+          }));
+
+          changes.push({
+            section: newSection.title,
+            type: 'MODIFIED',
+            details,
+          });
+        }
       }
-      // If not meaningful, silently ignore the change
+      // If hash identical, no change - skip entirely
+    } else {
+      pendingNewSections.push(newSection);
     }
-    // If hash identical, no change - skip entirely
   }
 
-  // Check for REMOVED sections
-  for (const oldSection of oldSections) {
-    if (!newMap.has(oldSection.title)) {
-      changes.push({ section: oldSection.title, type: 'REMOVED' });
+  // PASS 2: Fuzzy Title Matching for remaining new sections
+  for (const newSection of pendingNewSections) {
+    let bestMatchTitle: string | null = null;
+    let bestScore = 0;
+
+    // Find best match among remaining old sections
+    for (const [oldTitle] of unmatchedOldSections) {
+      const score = calculateTitleSimilarity(newSection.title, oldTitle);
+      if (score > bestScore) {
+        bestScore = score;
+        bestMatchTitle = oldTitle;
+      }
     }
+
+    if (bestMatchTitle && bestScore >= TITLE_SIMILARITY_THRESHOLD) {
+      const oldSection = unmatchedOldSections.get(bestMatchTitle)!;
+      unmatchedOldSections.delete(bestMatchTitle);
+
+      // Similarity threshold met -> treat as MODIFIED
+      const diffResult = calculateChangeRatio(oldSection.content, newSection.content);
+      const details: DiffDetail[] = diffResult.diff.map((part) => ({
+        value: part.value,
+        added: part.added === true,
+        removed: part.removed === true,
+      }));
+
+      changes.push({
+        section: newSection.title,
+        type: 'MODIFIED',
+        details,
+      });
+    } else {
+      // No match found -> ADDED
+      changes.push({ section: newSection.title, type: 'ADDED' });
+    }
+  }
+
+  // Remaining unmatched old sections -> REMOVED
+  for (const [oldTitle] of unmatchedOldSections) {
+    changes.push({ section: oldTitle, type: 'REMOVED' });
   }
 
   return changes;


### PR DESCRIPTION
**Implements deterministic fuzzy section title matching to reduce false ADDED/REMOVED classifications when section titles are slightly modified.**

1. Uses Levenshtein distance with strict similarity threshold
2. Applies only when exact match fails
3. Maintains one-to-one matching
4. No changes to API response contract
5. No changes to hashing logic
6. Deterministic and bounded complexity

Improves resilience against minor section title rewording without introducing semantic ambiguity.