### PR TITLE
Apply meaningful content threshold to fuzzy-match sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The system is built on a foundation of discrete, purposeful features:
 -   **Canonicalized URLs**: Normalizes URLs to prevent duplicate tracking of the same page (e.g., `http://` vs `https://`, trailing slashes, query parameters).
 -   **Section Extraction**: Parses HTML into logical sections using `<h1>`, `<h2>`, and `<h3>` tags as delimiters.
 -   **Section-Level Hashing**: Generates a SHA-256 hash for each section's content, enabling rapid detection of modifications.
--   **Structural Diff Engine**: Identifies changes as `ADDED`, `REMOVED`, or `MODIFIED` at the section level. Sections are matched using exact title match first. If an exact match fails, deterministic Levenshtein similarity matching is applied with a threshold of 0.85 to prevent minor title edits from being misclassified as `REMOVED` + `ADDED`.
+-   **Structural Diff Engine**: Identifies changes as `ADDED`, `REMOVED`, or `MODIFIED` at the section level. Sections are matched using exact title match first. If an exact match fails, deterministic Levenshtein similarity matching is applied with a threshold of 0.85 to prevent minor title edits from being misclassified as `REMOVED` + `ADDED`. Fuzzy title matches undergo full hash comparison and meaningful change validation before being classified as `MODIFIED`.
 -   **Meaningful Change Threshold**: Ignores modifications below a certain threshold (e.g., minor punctuation changes) to reduce noise.
 -   **Rule-Based Risk Engine**: Classifies changes using a predefined, deterministic set of keywords and rules.
 -   **Global Risk Aggregation**: Aggregates section-level risks into a single `LOW`, `MEDIUM`, or `HIGH` risk score for the entire document change.

--- a/src/services/differ.service.ts
+++ b/src/services/differ.service.ts
@@ -171,19 +171,25 @@ export function diffSections(oldSections: Section[], newSections: Section[]): Ch
       const oldSection = unmatchedOldSections.get(bestMatchTitle)!;
       unmatchedOldSections.delete(bestMatchTitle);
 
-      // Similarity threshold met -> treat as MODIFIED
-      const diffResult = calculateChangeRatio(oldSection.content, newSection.content);
-      const details: DiffDetail[] = diffResult.diff.map((part) => ({
-        value: part.value,
-        added: part.added === true,
-        removed: part.removed === true,
-      }));
+      // Similarity threshold met -> check content
+      if (oldSection.hash !== newSection.hash) {
+        const meaningfulChange = getMeaningfulChange(oldSection.content, newSection.content);
 
-      changes.push({
-        section: newSection.title,
-        type: 'MODIFIED',
-        details,
-      });
+        if (meaningfulChange.isMeaningful && meaningfulChange.diff) {
+          const details: DiffDetail[] = meaningfulChange.diff.map((part) => ({
+            value: part.value,
+            added: part.added === true,
+            removed: part.removed === true,
+          }));
+
+          changes.push({
+            section: newSection.title,
+            type: 'MODIFIED',
+            details,
+          });
+        }
+      }
+      // If hash identical or change not meaningful, treat as no change
     } else {
       // No match found -> ADDED
       changes.push({ section: newSection.title, type: 'ADDED' });

--- a/src/services/monitorJob.service.ts
+++ b/src/services/monitorJob.service.ts
@@ -6,7 +6,13 @@ import { generateHash } from '../utils/hash';
 import { canonicalizeUrl } from '../utils/canonicalizeUrl';
 import { diffSections } from './differ.service';
 import { analyzeRisk } from './riskEngine.service';
-import { acquireJob, releaseJob, canAcquireJob, getActiveJobCount, getMaxConcurrentJobs } from '../utils/concurrencyGuard';
+import {
+  acquireJob,
+  releaseJob,
+  canAcquireJob,
+  getActiveJobCount,
+  getMaxConcurrentJobs,
+} from '../utils/concurrencyGuard';
 import { ensurePageExists } from '../repositories/page.repository';
 import {
   createJob,
@@ -282,9 +288,10 @@ export async function processMonitorJob(jobId: string, logger?: Logger): Promise
         logger.info({ jobId, status: 'COMPLETED' }, 'Job completed successfully');
       }
     } catch (pipelineError) {
-      const errorType = pipelineError instanceof Error && pipelineError.message === 'JOB_TIMEOUT'
-        ? 'JOB_TIMEOUT'
-        : classifyError(pipelineError);
+      const errorType =
+        pipelineError instanceof Error && pipelineError.message === 'JOB_TIMEOUT'
+          ? 'JOB_TIMEOUT'
+          : classifyError(pipelineError);
 
       await markJobFailed(jobId, errorType as JobErrorType);
 


### PR DESCRIPTION
**Ensures fuzzy title matches are validated using the same meaningful change threshold logic as exact matches.**

1. Applies hash comparison after fuzzy match
2. Runs meaningful change check when hashes differ
3. Prevents trivial content edits from being flagged as MODIFIED
4. Maintains deterministic behavior
5. No API contract changes
6. No new change types introduced

_Improves classification accuracy and reduces false positive modifications caused by minor edits._