### PR TITLE
fix(parser): isolate main compliance content to prevent navbar/header diff noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The system is intentionally **deterministic** and avoids probabilistic AI models
 The system is built on a foundation of discrete, purposeful features:
 
 -   **Snapshot System**: Validates fetched content before versioning. Detects and rejects JS-heavy SPA shells, bot-blocked pages, or insufficient meaningful content before snapshotting.
+-   **Content Isolation Layer**: Deterministically isolates the primary policy content container (e.g., `<main>`, `<article>`) while removing global noise like headers, navbars, and footers. This prevents false positives caused by layout changes.
 -   **HTML Normalization**: Strips scripts, styles, and other non-content tags to isolate meaningful text.
 -   **Canonicalized URLs**: Normalizes URLs to prevent duplicate tracking of the same page (e.g., `http://` vs `https://`, trailing slashes, query parameters).
 -   **Section Extraction**: Parses HTML into logical sections using `<h1>`, `<h2>`, and `<h3>` tags as delimiters.
@@ -84,6 +85,12 @@ The application follows a standard layered architecture to ensure a clear separa
 -   **Controllers**: Handle HTTP request/response logic, validate input, and orchestrate calls to the service layer. They are responsible for the API contract.
 -   **Services**: Contain the core business logic. They are unaware of HTTP and focus on executing the monitoring pipeline, managing jobs, and performing risk analysis.
 -   **Repositories**: Abstract database interactions. They handle all SQL queries and data mapping, providing a clean interface to the service layer.
+
+### Monitoring Pipeline Flow
+
+The core analysis pipeline follows a deterministic lifecycle:
+
+`fetch → normalize → isolate content → section parse → hash → diff`
 
 This separation ensures that business logic is independent of the transport layer (Fastify) and the persistence layer (PostgreSQL), making the system easier to test, maintain, and evolve.
 
@@ -194,12 +201,13 @@ The core pipeline executes in the following order:
     -   **Dynamic JS-rendered pages**: Detected via SPA shells (e.g., `#root`, `#app`) or high script-to-text ratios.
     -   **Bot-protected or blocked pages**: Detected via common patterns (e.g., CAPTCHA, Cloudflare, access denied messages).
     -   **Insufficient content**: Pages with less than 300 characters of meaningful text.
-4.  **Hash Comparison**: The normalized content is hashed. If this hash matches the hash of the most recent `page_version`, the process exits early ("No meaningful change detected").
-4.  **Section Extraction**: The HTML is parsed, and content is grouped into sections based on `<h1>`, `<h2>`, and `<h3>` tags. Each section's content is also hashed.
-5.  **Structural Diff**: The new sections are compared to the sections from the previous version. The engine identifies `ADDED`, `REMOVED`, and `MODIFIED` sections. Minor modifications are ignored.
-6.  **Risk Classification**: Each change is passed through the expanded deterministic risk engine, which assigns a risk level (`LOW`, `MEDIUM`, `HIGH`) and a reason based on keyword matches or section type (e.g. low-impact removal of informational sections).
-7.  **Result Storage**: If changes were found, a new record is created in `page_versions`. The final analysis is stored in the `monitor_jobs` table's `result` column.
-8.  **Job Completion**: The job status is updated to `COMPLETED` or `FAILED`.
+4.  **Content Isolation**: The engine deterministically isolates the primary policy content container (e.g., `main`, `article`, `#content`) and removes global layout noise like `header`, `nav`, and `footer`. If no suitable container is found, it falls back to the `body`.
+5.  **Hash Comparison**: The normalized content is hashed. If this hash matches the hash of the most recent `page_version`, the process exits early ("No meaningful change detected").
+6.  **Section Extraction**: The HTML is parsed, and content is grouped into sections based on `<h1>`, `<h2>`, and `<h3>` tags. Each section's content is also hashed.
+7.  **Structural Diff**: The new sections are compared to the sections from the previous version. The engine identifies `ADDED`, `REMOVED`, and `MODIFIED` sections. Minor modifications are ignored.
+8.  **Risk Classification**: Each change is passed through the expanded deterministic risk engine, which assigns a risk level (`LOW`, `MEDIUM`, `HIGH`) and a reason based on keyword matches or section type (e.g. low-impact removal of informational sections).
+9.  **Result Storage**: If changes were found, a new record is created in `page_versions`. The final analysis is stored in the `monitor_jobs` table's `result` column.
+10. **Job Completion**: The job status is updated to `COMPLETED` or `FAILED`.
 
 ## 8. API Reference
 
@@ -398,6 +406,8 @@ Clients must provide an `X-Internal-Token: <token>` header to access this endpoi
   "high_risk_count": 45,
   "medium_risk_count": 120,
   "low_risk_count": 935,
+  "content_isolation_success_count": 1050,
+  "content_isolation_fallback_count": 50,
   "failure_breakdown": {
     "TIMEOUT": 20,
     "DNS_ERROR": 15,
@@ -467,6 +477,38 @@ The system uses a deterministic error classification model. Internal application
 -   `INTERNAL_ERROR`: An unexpected server-side error occurred.
 
 All errors are logged with a `request_id` to correlate client reports with server-side logs for efficient debugging.
+
+## Content Isolation Layer
+
+PolicyDiff includes a deterministic **Content Isolation Layer** that executes before section extraction. Full DOM parsing often includes navigation bars, headers, footers, and other global layout elements that are unrelated to the actual compliance document. When these global elements change (e.g., a menu item is added), it can cause "false positive" changes in the diff engine.
+
+### Isolation Strategy
+
+The Isolation Layer uses a deterministic multi-stage strategy:
+
+1.  **Global Noise Removal**: Irrelevant elements are removed from the DOM, including `header`, `nav`, `footer`, `aside`, `script`, `style`, `noscript`, `iframe`, `button`, and `form`.
+2.  **Deterministic Container Selection**: The engine searches for primary content containers in a fixed priority order:
+    -   `<main>`
+    -   `<article>`
+    -   `[role="main"]`
+    -   `#content`
+    -   `#main`
+    -   `.content`
+    -   `.policy`
+    -   `.terms`
+3.  **Length Validation**: Any candidate container must contain at least **500 characters** of text to be considered valid.
+4.  **Rank Selection**: If multiple candidates exist, the one with the largest text volume is selected.
+5.  **Fallback Mechanism**: If no suitable container is identified, the engine falls back to the `<body>` element.
+
+### Success vs. Fallback
+
+The isolation status is tracked and available in system metrics:
+-   **Success**: A primary container was successfully identified and isolated.
+-   **Fallback**: No container was found, and the full body was used (after global noise removal).
+
+### Limitations
+
+The Isolation Layer relies on standard semantic HTML or common CSS conventions. If a site uses non-standard layouts or embeds policy content inside deeply nested, non-semantic `<div>` structures without standard IDs or classes, the engine may fall back to the full body.
 
 ## 10. Performance & Optimization
 

--- a/src/repositories/metrics.repository.ts
+++ b/src/repositories/metrics.repository.ts
@@ -9,6 +9,8 @@ export type MetricsResponse = {
   high_risk_count: number;
   medium_risk_count: number;
   low_risk_count: number;
+  content_isolation_success_count: number;
+  content_isolation_fallback_count: number;
   failure_breakdown: {
     TIMEOUT: number;
     DNS_FAILURE: number;
@@ -29,6 +31,8 @@ export async function getInternalMetrics(): Promise<MetricsResponse> {
     high_risk_count: string;
     medium_risk_count: string;
     low_risk_count: string;
+    content_isolation_success_count: string;
+    content_isolation_fallback_count: string;
   }>(`
     SELECT 
         COUNT(*) as total_jobs,
@@ -38,7 +42,9 @@ export async function getInternalMetrics(): Promise<MetricsResponse> {
         AVG(EXTRACT(EPOCH FROM (completed_at - started_at)) * 1000) FILTER (WHERE status = 'COMPLETED' AND completed_at IS NOT NULL AND started_at IS NOT NULL) as average_processing_time_ms,
         COUNT(*) FILTER (WHERE result->>'risk_level' = 'HIGH') as high_risk_count,
         COUNT(*) FILTER (WHERE result->>'risk_level' = 'MEDIUM') as medium_risk_count,
-        COUNT(*) FILTER (WHERE result->>'risk_level' = 'LOW') as low_risk_count
+        COUNT(*) FILTER (WHERE result->>'risk_level' = 'LOW') as low_risk_count,
+        COUNT(*) FILTER (WHERE result->>'content_isolation' = 'success') as content_isolation_success_count,
+        COUNT(*) FILTER (WHERE result->>'content_isolation' = 'fallback') as content_isolation_fallback_count
     FROM monitor_jobs
   `);
 
@@ -72,6 +78,8 @@ export async function getInternalMetrics(): Promise<MetricsResponse> {
     high_risk_count: parseInt(summary.high_risk_count, 10),
     medium_risk_count: parseInt(summary.medium_risk_count, 10),
     low_risk_count: parseInt(summary.low_risk_count, 10),
+    content_isolation_success_count: parseInt(summary.content_isolation_success_count, 10),
+    content_isolation_fallback_count: parseInt(summary.content_isolation_fallback_count, 10),
     failure_breakdown: failure_breakdown as MetricsResponse['failure_breakdown'],
   };
 }

--- a/src/services/monitorJob.service.ts
+++ b/src/services/monitorJob.service.ts
@@ -2,6 +2,7 @@ import { DB } from '../db';
 import { fetchPage } from '../utils/fetchPage';
 import { normalizeContent } from './normalizer.service';
 import { extractSections } from './sectionExtractor.service';
+import { extractMainContent } from '../utils/mainContentExtractor';
 import { generateHash } from '../utils/hash';
 import { canonicalizeUrl } from '../utils/canonicalizeUrl';
 import { diffSections } from './differ.service';
@@ -320,7 +321,7 @@ export async function processMonitorJob(jobId: string, logger?: Logger): Promise
  * Execute the full monitoring pipeline for a page
  *
  * This is the core processing logic extracted from the sync flow.
- * It performs: fetch → normalize → extract → diff → risk analysis
+ * It performs: fetch → normalize → isolate → extract → diff → risk analysis
  *
  * @param pageId - Database ID of the page
  * @param url - Canonical URL to fetch
@@ -337,13 +338,19 @@ async function executeMonitoringPipeline(
   // Fetch page content (respects AbortSignal)
   const rawHtml = await fetchPage(url, signal);
 
+  // Content Isolation Layer
+  const { html: isolatedHtml, status: isolationStatus } = extractMainContent(rawHtml);
+
   // Normalize and extract sections
-  const normalizedContent = normalizeContent(rawHtml);
-  const sections = extractSections(rawHtml);
+  const normalizedContent = normalizeContent(isolatedHtml);
+  const sections = extractSections(isolatedHtml);
   const contentHash = generateHash(normalizedContent);
 
   if (logger) {
-    logger.debug({ pageId, contentHash, sectionCount: sections.length }, 'Content processed');
+    logger.debug(
+      { pageId, contentHash, sectionCount: sections.length, isolationStatus },
+      'Content processed',
+    );
   }
 
   // Check if signal aborted before heavy operations
@@ -372,13 +379,19 @@ async function executeMonitoringPipeline(
 
     // Check if content changed
     if (latestHash === contentHash) {
-      diffResult = { message: 'No meaningful change detected' };
+      diffResult = {
+        message: 'No meaningful change detected',
+        content_isolation: isolationStatus,
+      };
     } else {
       // Calculate diff
       const changes = diffSections(latestSections, sections);
 
       if (changes.length === 0) {
-        diffResult = { message: 'No meaningful change detected' };
+        diffResult = {
+          message: 'No meaningful change detected',
+          content_isolation: isolationStatus,
+        };
       } else {
         // Analyze risk
         const riskAnalysis = analyzeRisk(changes, sections);
@@ -387,6 +400,7 @@ async function executeMonitoringPipeline(
           message: 'Changes detected',
           risk_level: riskAnalysis.risk_level,
           changes: riskAnalysis.changes,
+          content_isolation: isolationStatus,
         };
 
         // Store new version
@@ -407,7 +421,10 @@ async function executeMonitoringPipeline(
       JSON.stringify(sections),
     ]);
 
-    diffResult = { message: 'First snapshot stored' };
+    diffResult = {
+      message: 'First snapshot stored',
+      content_isolation: isolationStatus,
+    };
   }
 
   // Update page cache

--- a/src/services/page.service.ts
+++ b/src/services/page.service.ts
@@ -2,6 +2,7 @@ import { fetchPage } from '../utils/fetchPage';
 import { savePage, getPageInfo, checkCooldown, updatePageCache } from '../repositories/page.repository';
 import { normalizeContent } from './normalizer.service';
 import { extractSections } from './sectionExtractor.service';
+import { extractMainContent } from '../utils/mainContentExtractor';
 import { generateHash } from '../utils/hash';
 import { canonicalizeUrl } from '../utils/canonicalizeUrl';
 import { DiffResult, CheckResult } from '../types';
@@ -76,24 +77,37 @@ export async function checkPage(rawUrl: string, options: CheckPageOptions = {}):
 
   // Fetch and process page
   const rawHtml = await fetchPage(canonicalUrl);
-  const normalizedContent = normalizeContent(rawHtml);
-  const sections = extractSections(rawHtml);
+
+  // Content Isolation Layer
+  const { html: isolatedHtml, status: isolationStatus } = extractMainContent(rawHtml);
+
+  const normalizedContent = normalizeContent(isolatedHtml);
+  const sections = extractSections(isolatedHtml);
   const contentHash = generateHash(normalizedContent);
 
   // Save using ONLY the canonical URL
   const saveResult = await savePage(canonicalUrl, normalizedContent, contentHash, sections);
 
   if (logger) {
-    logger.debug({ canonicalUrl, pageId: saveResult.pageId, status: saveResult.status }, 'Page processed');
+    logger.debug(
+      { canonicalUrl, pageId: saveResult.pageId, status: saveResult.status, isolationStatus },
+      'Page processed',
+    );
   }
 
   // Build the diff result
   let diffResult: DiffResult;
 
   if (saveResult.status === 'first_version') {
-    diffResult = { message: 'First snapshot stored' };
+    diffResult = {
+      message: 'First snapshot stored',
+      content_isolation: isolationStatus,
+    };
   } else if (saveResult.status === 'unchanged') {
-    diffResult = { message: 'No meaningful change detected' };
+    diffResult = {
+      message: 'No meaningful change detected',
+      content_isolation: isolationStatus,
+    };
   } else {
     const changes = saveResult.changes || [];
     const riskAnalysis = analyzeRisk(changes, sections);
@@ -102,6 +116,7 @@ export async function checkPage(rawUrl: string, options: CheckPageOptions = {}):
       message: 'Changes detected',
       risk_level: riskAnalysis.risk_level,
       changes: riskAnalysis.changes,
+      content_isolation: isolationStatus,
     };
   }
 

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -1,0 +1,55 @@
+/**
+ * Section extracted from HTML page
+ * Includes content hash for efficient comparison
+ */
+export type Section = {
+  title: string;
+  content: string;
+  /** SHA-256 hash of normalized content for fast comparison */
+  hash: string;
+};
+
+export type ChangeType = 'ADDED' | 'REMOVED' | 'MODIFIED';
+
+export interface DiffDetail {
+  value: string;
+  added: boolean;
+  removed: boolean;
+}
+
+export type Change = {
+  section: string;
+  type: ChangeType;
+  details?: DiffDetail[];
+};
+
+export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
+
+export type RiskedChange = {
+  section: string;
+  type: ChangeType;
+  risk: RiskLevel;
+  reason: string;
+  details?: DiffDetail[];
+};
+
+/**
+ * Standard diff result returned by check endpoint
+ */
+export type DiffResult = {
+  message: string;
+  risk_level?: RiskLevel;
+  changes?: RiskedChange[];
+  /** Isolation status for internal metrics */
+  content_isolation?: 'success' | 'fallback';
+};
+
+/**
+ * Extended check result including skip status
+ */
+export type CheckResult = {
+  status: 'processed' | 'skipped';
+  reason?: string;
+  last_checked?: string;
+  result?: DiffResult;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,56 +1,5 @@
-/**
- * Section extracted from HTML page
- * Includes content hash for efficient comparison
- */
-export type Section = {
-  title: string;
-  content: string;
-  /** SHA-256 hash of normalized content for fast comparison */
-  hash: string;
-};
-
-export type ChangeType = 'ADDED' | 'REMOVED' | 'MODIFIED';
-
-export interface DiffDetail {
-  value: string;
-  added: boolean;
-  removed: boolean;
-}
-
-export type Change = {
-  section: string;
-  type: ChangeType;
-  details?: DiffDetail[];
-};
-
-export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
-
-export type RiskedChange = {
-  section: string;
-  type: ChangeType;
-  risk: RiskLevel;
-  reason: string;
-  details?: DiffDetail[];
-};
-
-/**
- * Standard diff result returned by check endpoint
- */
-export type DiffResult = {
-  message: string;
-  risk_level?: RiskLevel;
-  changes?: RiskedChange[];
-};
-
-/**
- * Extended check result including skip status
- */
-export type CheckResult = {
-  status: 'processed' | 'skipped';
-  reason?: string;
-  last_checked?: string;
-  result?: DiffResult;
-};
+// Export all base types
+export * from './diff';
 
 // Re-export auth types
 export * from './auth';

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -11,7 +11,7 @@
  * FAILED: Job failed, error_type indicates cause
  */
 
-import { DiffResult } from './index';
+import { DiffResult } from './diff';
 
 /**
  * Job status enum values

--- a/src/utils/mainContentExtractor.ts
+++ b/src/utils/mainContentExtractor.ts
@@ -1,0 +1,83 @@
+import * as cheerio from 'cheerio';
+
+/**
+ * Deterministic Content Isolation Layer
+ *
+ * This utility isolates the primary policy content container from HTML,
+ * removing noise from navbars, headers, footers, and other layout elements.
+ *
+ * WHY ISOLATE CONTENT:
+ * - Prevents false positives when global navbars/footers change
+ * - Improves precision of section extraction
+ * - Focuses compliance analysis on actual document content
+ */
+
+/**
+ * Extract the primary policy content from raw HTML
+ *
+ * @param html - Raw HTML string
+ * @returns Sanitized inner HTML of the chosen container, or body if none found
+ */
+export function extractMainContent(html: string): { html: string; status: 'success' | 'fallback' } {
+  const $ = cheerio.load(html);
+
+  // 1. Remove irrelevant elements globally
+  const unwantedElements = [
+    'header',
+    'nav',
+    'footer',
+    'aside',
+    'script',
+    'style',
+    'noscript',
+    'iframe',
+    'button',
+    'form',
+  ];
+  $(unwantedElements.join(',')).remove();
+
+  // 2. Candidate containers in priority order
+  const candidates = [
+    'main',
+    'article',
+    '[role="main"]',
+    '#content',
+    '#main',
+    '.content',
+    '.policy',
+    '.terms',
+  ];
+
+  let bestCandidate: cheerio.Cheerio | null = null;
+  let maxTextLength = 0;
+
+  for (const selector of candidates) {
+    const elements = $(selector);
+    elements.each((_, element) => {
+      const $el = $(element);
+      const text = $el.text();
+      const length = text.replace(/\s+/g, '').length;
+
+      // Ignore if length < 500 characters
+      if (length >= 500) {
+        if (length > maxTextLength) {
+          maxTextLength = length;
+          bestCandidate = $el;
+        }
+      }
+    });
+  }
+
+  // 3. Fallback to body if no suitable candidate found
+  if (bestCandidate) {
+    return {
+      html: (bestCandidate as cheerio.Cheerio).html() || '',
+      status: 'success',
+    };
+  }
+
+  return {
+    html: $('body').html() || html,
+    status: 'fallback',
+  };
+}


### PR DESCRIPTION
- Implemented deterministic main content isolation layer
- Removed header, nav, footer, and layout elements before parsing
- Added container selection priority (main, article, role=main, etc.)
- Fallback to body when no container detected
- Integrated isolation before section extraction
- Added isolation metrics
- Updated README with architecture changes
- Improved diff precision without breaking response contract
