### PR TITLE
feat(diff): deterministic section title rename detection via content hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ The system is built on a foundation of discrete, purposeful features:
 -   **Canonicalized URLs**: Normalizes URLs to prevent duplicate tracking of the same page (e.g., `http://` vs `https://`, trailing slashes, query parameters).
 -   **Section Extraction**: Parses HTML into logical sections using `<h1>`, `<h2>`, and `<h3>` tags as delimiters.
 -   **Section-Level Hashing**: Generates a SHA-256 hash for each section's content, enabling rapid detection of modifications.
--   **Structural Diff Engine**: Identifies changes as `ADDED`, `REMOVED`, or `MODIFIED` at the section level. Sections are matched using exact title match first. If an exact match fails, deterministic Levenshtein similarity matching is applied with a threshold of 0.85 to prevent minor title edits from being misclassified as `REMOVED` + `ADDED`. Fuzzy title matches undergo full hash comparison and meaningful change validation before being classified as `MODIFIED`.
+-   **Structural Diff Engine**: Identifies changes as `ADDED`, `DELETED`, or `MODIFIED` at the section level. Sections are matched using exact title match first. If an exact match fails, deterministic Levenshtein similarity matching is applied with a threshold of 0.85 to prevent minor title edits from being misclassified as `DELETED` + `ADDED`. Fuzzy title matches undergo full hash comparison and meaningful change validation before being classified as `MODIFIED`.
+-   **Stable Section Tracking**: Detects section renames by comparing exact content hashes when title matching fails.
 -   **Meaningful Change Threshold**: Ignores modifications below a certain threshold (e.g., minor punctuation changes) to reduce noise.
 -   **Rule-Based Risk Engine**: Classifies changes using an expanded deterministic keyword coverage aligned with modern compliance frameworks (GDPR, CCPA, arbitration, indemnification, biometric data, jurisdiction clauses).
     -   **HIGH risk** includes legal rights waivers, sensitive regulated data, and aggressive unilateral clauses.
@@ -202,7 +203,7 @@ The core pipeline executes in the following order:
 4.  **Content Isolation**: The engine deterministically isolates the primary policy content container (e.g., `main`, `article`, `#content`) and removes global layout noise like `header`, `nav`, and `footer`. If no suitable container is found, it falls back to the `body`.
 5.  **Hash Comparison**: The normalized content is hashed. If this hash matches the hash of the most recent `page_version`, the process exits early ("No meaningful change detected").
 6.  **Section Extraction**: The HTML is parsed, and content is grouped into sections based on `<h1>`, `<h2>`, and `<h3>` tags. Each section's content is also hashed.
-7.  **Structural Diff**: The new sections are compared to the sections from the previous version. The engine identifies `ADDED`, `REMOVED`, and `MODIFIED` sections. Minor modifications are ignored.
+7.  **Structural Diff**: The new sections are compared to the sections from the previous version. The engine identifies `ADDED`, `DELETED`, and `MODIFIED` sections. Minor modifications are ignored.
 8.  **Risk Classification**: Each change is passed through the expanded deterministic risk engine, which assigns a risk level (`LOW`, `MEDIUM`, `HIGH`) and a reason based on keyword matches or section type (e.g. low-impact removal of informational sections).
 9.  **Result Storage**: If changes were found, a new record is created in `page_versions`. The final analysis is stored in the `monitor_jobs` table's `result` column.
 10. **Job Completion**: The job status is updated to `COMPLETED` or `FAILED`.
@@ -501,6 +502,29 @@ This transformation occurs before:
 - Hash Computation
 
 No heuristics or AI are involved.
+
+## Stable Section Tracking
+
+PolicyDiff detects deterministic title renames.
+
+If a section title changes but its content hash remains identical,
+the system classifies it as:
+
+`TITLE_RENAMED`
+
+This ensures:
+
+- Historical continuity of legal clauses
+- No false `ADDED`/`DELETED` noise
+- Deterministic one-to-one section mapping
+
+Matching order:
+
+1. Exact title match
+2. Fuzzy title match (Levenshtein ≥ 0.85)
+3. Exact content hash match (rename detection)
+
+No semantic or AI similarity is used.
 
 ## Content Isolation Layer
 

--- a/src/services/differ.service.test.ts
+++ b/src/services/differ.service.test.ts
@@ -1,0 +1,114 @@
+import { diffSections } from './differ.service';
+import { Section, Change } from '../types';
+
+/**
+ * Structural Diff Engine Unit Tests
+ *
+ * Includes Pass 3B (TITLE_RENAMED) validation
+ */
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    throw new Error(`Assertion Failed: ${message}`);
+  }
+}
+
+function runTests() {
+  console.log('Running Structural Diff Engine Tests...');
+
+  // 1. Title changed, content identical -> TITLE_RENAMED
+  const oldSections1: Section[] = [{ title: 'Privacy Policy', content: 'We value your privacy.', hash: 'hash1' }];
+  const newSections1: Section[] = [
+    { title: 'Data Protection Policy', content: 'We value your privacy.', hash: 'hash1' },
+  ];
+  const changes1 = diffSections(oldSections1, newSections1);
+  assert(changes1.length === 1, 'Should have 1 change');
+  assert(changes1[0].type === 'TITLE_RENAMED', 'Should be TITLE_RENAMED');
+  if (changes1[0].type === 'TITLE_RENAMED') {
+    assert(changes1[0].oldTitle === 'Privacy Policy', 'Old title mismatch');
+    assert(changes1[0].newTitle === 'Data Protection Policy', 'New title mismatch');
+    assert(changes1[0].contentHash === 'hash1', 'Hash mismatch');
+  }
+
+  // 2. Title changed, content different -> MODIFIED (via fuzzy) or DELETED+ADDED
+  // If similarity < 0.85 and hash different -> DELETED + ADDED
+  const oldSections2: Section[] = [{ title: 'Introduction', content: 'Old content', hash: 'hash-old' }];
+  const newSections2: Section[] = [{ title: 'Overview', content: 'New content', hash: 'hash-new' }];
+  const changes2 = diffSections(oldSections2, newSections2);
+  // 'Introduction' vs 'Overview' similarity is low
+  assert(
+    changes2.some(
+      (c) => c.type === 'DELETED' && (c as Extract<Change, { type: 'DELETED' }>).section === 'Introduction',
+    ),
+    'Should have DELETED Introduction',
+  );
+  assert(
+    changes2.some((c) => c.type === 'ADDED' && (c as Extract<Change, { type: 'ADDED' }>).section === 'Overview'),
+    'Should have ADDED Overview',
+  );
+
+  // 3. Two sections swap names (no exact title overlap) but identical content -> deterministic one-to-one mapping
+  const oldSections3: Section[] = [
+    { title: 'Old Section A', content: 'Content 1', hash: 'h1' },
+    { title: 'Old Section B', content: 'Content 2', hash: 'h2' },
+  ];
+  const newSections3: Section[] = [
+    { title: 'New Section B', content: 'Content 1', hash: 'h1' },
+    { title: 'New Section A', content: 'Content 2', hash: 'h2' },
+  ];
+  const changes3 = diffSections(oldSections3, newSections3);
+  // Section A (old) matches Section B (new) via hash h1 -> TITLE_RENAMED
+  // Section B (old) matches Section A (new) via hash h2 -> TITLE_RENAMED
+  assert(changes3.length === 2, 'Should have 2 renames');
+  assert(
+    changes3.every((c) => c.type === 'TITLE_RENAMED'),
+    'All should be TITLE_RENAMED',
+  );
+
+  // 4. Content identical across multiple sections -> only first deterministic match allowed
+  const oldSections4: Section[] = [
+    { title: 'Old 1', content: 'Same', hash: 'same-hash' },
+    { title: 'Old 2', content: 'Same', hash: 'same-hash' },
+  ];
+  const newSections4: Section[] = [{ title: 'New 1', content: 'Same', hash: 'same-hash' }];
+  const changes4 = diffSections(oldSections4, newSections4);
+  // New 1 matches Old 1 -> TITLE_RENAMED
+  // Old 2 remains -> DELETED
+  assert(changes4.length === 2, 'Should have 2 changes (rename + delete)');
+  assert(
+    changes4.some((c) => c.type === 'TITLE_RENAMED'),
+    'Should have rename',
+  );
+  assert(
+    changes4.some((c) => c.type === 'DELETED'),
+    'Should have delete',
+  );
+
+  // 5. Title minor change that fuzzy would already catch -> must still use fuzzy first
+  const oldSections5: Section[] = [
+    {
+      title: 'Data Privacy',
+      content: 'This is the old content of the privacy policy.',
+      hash: 'h-old',
+    },
+  ];
+  const newSections5: Section[] = [
+    {
+      title: 'Data Privacies',
+      content: 'This is the new content with significant changes.',
+      hash: 'h-new',
+    },
+  ];
+  const changes5 = diffSections(oldSections5, newSections5);
+  // Similarity between 'Data Privacy' and 'Data Privacies' is > 0.85
+  // Should be MODIFIED, not TITLE_RENAMED (since hashes differ)
+  assert(changes5.length === 1, 'Should have 1 change');
+  assert(changes5[0].type === 'MODIFIED', 'Should be MODIFIED via fuzzy match');
+
+  console.log('All Structural Diff Engine Tests Passed.');
+}
+
+// Run tests
+runTests();
+
+export { runTests };

--- a/src/services/differ.service.ts
+++ b/src/services/differ.service.ts
@@ -14,7 +14,7 @@ import levenshtein from 'fast-levenshtein';
 const MEANINGFUL_CHANGE_THRESHOLD = 0.05; // 5%
 
 /**
- * Threshold for fuzzy title matching to prevent REMOVED + ADDED misclassification
+ * Threshold for fuzzy title matching to prevent DELETED + ADDED misclassification
  * when titles are slightly reworded.
  */
 const TITLE_SIMILARITY_THRESHOLD = 0.85;
@@ -139,7 +139,10 @@ function getMeaningfulChange(oldContent: string, newContent: string): { isMeanin
  * meaningful change filter to reduce noise from minor edits.
  *
  * Implements deterministic fuzzy section title matching to prevent
- * minor title edits from being classified as REMOVED + ADDED.
+ * minor title edits from being classified as DELETED + ADDED.
+ *
+ * Implements Pass 3B for deterministic title rename detection via exact
+ * content hash match.
  *
  * @param oldSections - Sections from previous version
  * @param newSections - Sections from current version
@@ -184,6 +187,7 @@ export function diffSections(oldSections: Section[], newSections: Section[]): Ch
   }
 
   // PASS 2: Fuzzy Title Matching for remaining new sections
+  const remainingAfterFuzzy: Section[] = [];
   for (const newSection of pendingNewSections) {
     let bestMatchTitle: string | null = null;
     let bestScore = 0;
@@ -221,14 +225,45 @@ export function diffSections(oldSections: Section[], newSections: Section[]): Ch
       }
       // If hash identical or change not meaningful, treat as no change
     } else {
-      // No match found -> ADDED
-      changes.push({ section: newSection.title, type: 'ADDED' });
+      // No fuzzy match found -> move to next pass
+      remainingAfterFuzzy.push(newSection);
     }
   }
 
-  // Remaining unmatched old sections -> REMOVED
+  // PASS 3B: CONTENT HASH MATCH (Rename Detection)
+  const remainingAfterHash: Section[] = [];
+  for (const newSection of remainingAfterFuzzy) {
+    let matchedOldTitle: string | null = null;
+
+    // Search for exact content hash match among remaining old sections
+    for (const [oldTitle, oldSection] of unmatchedOldSections) {
+      if (oldSection.hash === newSection.hash) {
+        matchedOldTitle = oldTitle;
+        break;
+      }
+    }
+
+    if (matchedOldTitle) {
+      unmatchedOldSections.delete(matchedOldTitle);
+      changes.push({
+        type: 'TITLE_RENAMED',
+        oldTitle: matchedOldTitle,
+        newTitle: newSection.title,
+        contentHash: newSection.hash,
+      });
+    } else {
+      remainingAfterHash.push(newSection);
+    }
+  }
+
+  // FINAL PASS: Classify remaining as ADDED or DELETED
+  for (const newSection of remainingAfterHash) {
+    changes.push({ section: newSection.title, type: 'ADDED' });
+  }
+
+  // Remaining unmatched old sections -> DELETED
   for (const [oldTitle] of unmatchedOldSections) {
-    changes.push({ section: oldTitle, type: 'REMOVED' });
+    changes.push({ section: oldTitle, type: 'DELETED' });
   }
 
   return changes;

--- a/src/services/riskEngine.service.ts
+++ b/src/services/riskEngine.service.ts
@@ -80,11 +80,11 @@ function detectTitleRisk(title: string): RiskLevel {
 }
 
 function evaluateChange(change: Change, newSections: Section[]): RiskedChange {
-  const { section, type } = change;
   let risk: RiskLevel = 'LOW';
   let reason = 'Minor wording change';
 
-  if (type === 'ADDED' || type === 'MODIFIED') {
+  if (change.type === 'ADDED' || change.type === 'MODIFIED') {
+    const { section } = change;
     const sectionContent = newSections.find((s) => s.title === section)?.content || '';
 
     if (detectHighRisk(sectionContent)) {
@@ -94,7 +94,14 @@ function evaluateChange(change: Change, newSections: Section[]): RiskedChange {
       risk = 'MEDIUM';
       reason = 'Medium risk keyword detected in content';
     }
-  } else if (type === 'REMOVED') {
+
+    return {
+      ...change,
+      risk,
+      reason,
+    };
+  } else if (change.type === 'DELETED') {
+    const { section } = change;
     const titleRisk = detectTitleRisk(section);
     if (titleRisk === 'HIGH') {
       risk = 'HIGH';
@@ -112,15 +119,22 @@ function evaluateChange(change: Change, newSections: Section[]): RiskedChange {
         reason = 'Section removed';
       }
     }
+
+    return {
+      ...change,
+      risk,
+      reason,
+    };
+  } else if (change.type === 'TITLE_RENAMED') {
+    return {
+      ...change,
+      risk: 'LOW',
+      reason: 'Section title renamed with identical content',
+    };
   }
 
-  return {
-    section,
-    type,
-    risk,
-    reason,
-    details: change.details,
-  };
+  const _exhaustiveCheck: never = change;
+  return _exhaustiveCheck;
 }
 
 export function analyzeRisk(

--- a/src/types/diff.ts
+++ b/src/types/diff.ts
@@ -2,6 +2,10 @@
  * Section extracted from HTML page
  * Includes content hash for efficient comparison
  */
+/**
+ * Section extracted from HTML page
+ * Includes content hash for efficient comparison
+ */
 export type Section = {
   title: string;
   content: string;
@@ -9,28 +13,25 @@ export type Section = {
   hash: string;
 };
 
-export type ChangeType = 'ADDED' | 'REMOVED' | 'MODIFIED';
+export type SectionDiffType = 'ADDED' | 'DELETED' | 'MODIFIED' | 'TITLE_RENAMED';
 
-export interface DiffDetail {
+export type DiffDetail = {
   value: string;
   added: boolean;
   removed: boolean;
-}
-
-export type Change = {
-  section: string;
-  type: ChangeType;
-  details?: DiffDetail[];
 };
+
+export type Change =
+  | { section: string; type: 'ADDED' }
+  | { section: string; type: 'DELETED' }
+  | { section: string; type: 'MODIFIED'; details: DiffDetail[] }
+  | { type: 'TITLE_RENAMED'; oldTitle: string; newTitle: string; contentHash: string };
 
 export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH';
 
-export type RiskedChange = {
-  section: string;
-  type: ChangeType;
+export type RiskedChange = Change & {
   risk: RiskLevel;
   reason: string;
-  details?: DiffDetail[];
 };
 
 /**


### PR DESCRIPTION
- Added content-hash based rename detection pass
- Introduced TITLE_RENAMED diff type
- Deterministic one-to-one mapping
- Preserved existing title matching order
- Added unit tests for rename scenarios
- Updated README documentation

Improves section continuity without introducing heuristics or semantic similarity.
