### PR TITLE
feat: add deterministic internal API key provisioning endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ lerna-debug.log*
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+A_Z_CODEBASE_PROMPT.md
 
 # Runtime data
 pids

--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ The system is built on a foundation of discrete, purposeful features:
 -   **API Key Authentication**: Secures all endpoints with bearer token authentication.
 -   **Dev vs. Prod Keys**: Supports separate key environments (`pd_dev_...`, `pd_prod_...`) for safe development and testing.
 -   **SHA-256 Key Hashing**: Hashes all API keys before storage; raw keys are never stored.
--   **Rate Limiting**: Protects the API from abuse with a simple, per-key usage limit.
--   **Usage Tracking**: Increments a usage counter for each authenticated request.
+-   **Quota Enforcement**: Enforces per-key monthly job quotas with deterministic, backend-only atomic checks.
 -   **API Key Tiering**: Classifies keys into `FREE`, `PRO`, and `ENTERPRISE` tiers with explicit per-key quotas.
 -   **Usage Quotas**: Enforces per-key monthly job quotas with deterministic, backend-only checks.
 -   **Observability Layer**:
@@ -168,7 +167,7 @@ The database schema is designed to be normalized and efficient, with clear purpo
 
 -   **`api_keys`**
     -   **Purpose**: Manages API keys for authentication, rate limiting, and usage/tiers.
-    -   **Key Columns**: `id` (SERIAL PK), `key_hash` (UNIQUE TEXT), `usage_count` (INTEGER), `rate_limit` (INTEGER), `tier` (`FREE`/`PRO`/`ENTERPRISE`), `monthly_quota` (INTEGER), `monthly_usage` (INTEGER), `quota_reset_at` (TIMESTAMPTZ).
+    -   **Key Columns**: `id` (SERIAL PK), `key_hash` (UNIQUE TEXT), `email` (TEXT NOT NULL/UNIQUE), `tier` (`FREE`/`PRO`/`ENTERPRISE`), `monthly_quota` (INTEGER), `monthly_usage` (INTEGER), `quota_reset_at` (TIMESTAMPTZ).
     -   **Indexing**: A unique index on `key_hash` provides fast O(1) lookups during authentication. Additional indexes on `tier` and `quota_reset_at` support operational queries and maintenance.
 
 -   **`api_logs`**
@@ -441,6 +440,38 @@ A readiness probe that checks dependencies (e.g., database connection). Returns 
 }
 ```
 
+### `POST /v1/internal/provision`
+
+Endpoint to provision a new standard API key internally.
+
+**X-Provision-Secret Header:**
+Requires `X-Provision-Secret: <token>` configured by the `PROVISION_SECRET` env var.
+
+**Example Request:**
+
+```json
+{
+  "email": "user@example.com",
+  "name": "Production Key",
+  "tier": "FREE",
+  "environment": "live"
+}
+```
+
+**Example Response (200 OK):**
+
+```json
+{
+  "apiKey": "pd_live_a1b2c3d4e5f6...",
+  "warning": "Store this key securely. It will not be shown again."
+}
+```
+
+- Keys are generated securely with SHA-256 hashes in the database.
+- Enforces one active key per email.
+- Returns the key ONCE.
+- Replaces legacy per-key `usage_count` with monthly quota enforcement.
+
 **Error Contract:**
 
 All API errors follow a standard format.
@@ -697,7 +728,6 @@ PolicyDiff is designed for infrastructure-grade reliability. When deploying to p
 | `NODE_ENV` | Environment mode | `production` |
 | `PORT` | Listening port | Required |
 | `GLOBAL_RATE_LIMIT` | Requests per minute (all users) | Default: 1000 |
-| `PER_KEY_RATE_LIMIT` | Requests per minute (per API key) | Default: 100 |
 
 ### Deployment Checklist
 
@@ -715,7 +745,7 @@ PolicyDiff is designed for infrastructure-grade reliability. When deploying to p
 Welcome to PolicyDiff. Follow this guide to integrate the compliance signal engine into your workflow.
 
 ### 1. Obtain an API Key
-Currently, API keys are provisioned manually. Contact the administrator to request a key for your environment (`dev` or `prod`).
+Provision an API key using the internal provisioning endpoint `POST /v1/internal/provision` using your environment's `PROVISION_SECRET`.
 
 ### 2. Secure Storage
 Store your API key in a secure secret manager (e.g., AWS Secrets Manager, HashiCorp Vault). Never hardcode keys or commit them to source control.

--- a/scripts/generate-prompt.ts
+++ b/scripts/generate-prompt.ts
@@ -1,0 +1,133 @@
+import fs from 'fs';
+import path from 'path';
+
+const IGNORE_DIRS = [
+    'node_modules',
+    'dist',
+    '.git',
+    '.idea',
+    'coverage',
+    '.vscode',
+    'logs',
+    'build',
+    'docs',
+];
+const IGNORE_FILES = [
+    'package-lock.json',
+    '.DS_Store',
+    'A_Z_CODEBASE_PROMPT.md',
+    'AGENTS.md',
+    'GEMINI.md',
+    'GEMINI_STRATEGY.md',
+];
+const IGNORE_EXTENSIONS = ['.log', '.sqlite', '.sqlite3', '.gz', '.zip', '.tar', '.tgz'];
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+// Helper to check if a file/dir should be ignored
+function shouldIgnore(entryPath: string, isDirectory: boolean): boolean {
+    const baseName = path.basename(entryPath);
+    if (isDirectory) {
+        return IGNORE_DIRS.includes(baseName);
+    } else {
+        if (IGNORE_FILES.includes(baseName)) return true;
+        if (baseName.endsWith('.test.ts') || baseName.endsWith('.spec.ts')) return true; // Excluding tests to save tokens
+        const ext = path.extname(baseName);
+        if (IGNORE_EXTENSIONS.includes(ext)) return true;
+        return false;
+    }
+}
+
+// Generate directory tree
+function generateTree(dir: string, prefix = ''): string {
+    let output = '';
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    // Sort: directories first, then files
+    entries.sort((a, b) => {
+        if (a.isDirectory() && !b.isDirectory()) return -1;
+        if (!a.isDirectory() && b.isDirectory()) return 1;
+        return a.name.localeCompare(b.name);
+    });
+
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const fullPath = path.join(dir, entry.name);
+        if (shouldIgnore(fullPath, entry.isDirectory())) continue;
+
+        const isLast = i === entries.length - 1;
+        const marker = isLast ? '└── ' : '├── ';
+        output += `${prefix}${marker}${entry.name}\n`;
+
+        if (entry.isDirectory()) {
+            output += generateTree(fullPath, prefix + (isLast ? '    ' : '│   '));
+        }
+    }
+    return output;
+}
+
+// Gather all pertinent files content
+function gatherFiles(dir: string): { relativePath: string; content: string }[] {
+    let files: { relativePath: string; content: string }[] = [];
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (shouldIgnore(fullPath, entry.isDirectory())) continue;
+
+        if (entry.isDirectory()) {
+            files = files.concat(gatherFiles(fullPath));
+        } else {
+            const relPath = path.relative(ROOT_DIR, fullPath).replace(/\\/g, '/');
+            const content = fs.readFileSync(fullPath, 'utf8');
+            files.push({ relativePath: relPath, content });
+        }
+    }
+    return files;
+}
+
+function generatePrompt() {
+    const fileList = gatherFiles(ROOT_DIR);
+    const tree = generateTree(ROOT_DIR);
+
+    const promptContent = `
+# System Role
+You are an expert AI software engineer and backend architect. You are provided with the complete A-Z implementation of the "Policy Diff API" codebase. This is a deterministic API-first utility built with Node.js, Fastify, TypeScript, and PostgreSQL for monitoring website legal documents. 
+
+# Your Task
+Your goal is to deeply understand this entire codebase — its architecture, business logic, deterministic diff engine (Levenshtein distance + hashing), job queue system, and API layer — so that you can accurately answer questions, debug issues, or extend features. Note that tests are omitted to save context length.
+
+# Project Architecture & Guidelines (From User)
+1. **Focus on determinism**: The system avoids probabilistic AI for core diffing; it isolates HTML content, structural normalization (Markdown-like), hashes sections, and diffs them exactly.
+2. **Concurrency**: Job queue limits concurrency organically and by API Key using an in-memory guard in \`monitorJob.service.ts\`.
+3. **Database**: \`pg\` client pools are used directly for optimal efficiency over ORMs.
+4. **Security**: Tokens are hashed with SHA-256 before storage.
+
+---
+
+## 1. Directory Structure
+\`\`\`text
+.
+${tree.trim()}
+\`\`\`
+
+---
+
+## 2. Source Code Files
+The files below represent the complete implementation. They are delineated by XML-like tags \`<file>\` with a \`path\` attribute. Use this strictly as your source of truth.
+
+${fileList
+            .map(
+                (f) => '<file path="' + f.relativePath + '">\\n' + f.content.trim() + '\\n</file>'
+            )
+            .join('\n\n')}
+
+---
+**END OF CODEBASE**
+Please confirm that you have read and understood the entire implementation, and let me know if you are ready to assist with any questions or modifications!
+`.trim();
+
+    fs.writeFileSync(path.join(ROOT_DIR, 'A_Z_CODEBASE_PROMPT.md'), promptContent, 'utf8');
+    console.log('Successfully generated highly structured A_Z_CODEBASE_PROMPT.md');
+}
+
+generatePrompt();

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -52,10 +52,10 @@ export const PORT = getRequiredInt('PORT', 3000);
 export const DATABASE_URL = getRequiredEnv('DATABASE_URL');
 export const API_SECRET = getRequiredEnv('API_SECRET');
 export const INTERNAL_METRICS_TOKEN = getRequiredEnv('INTERNAL_METRICS_TOKEN');
+export const PROVISION_SECRET = getRequiredEnv('PROVISION_SECRET');
 
 // Rate Limiting (Configurable via env)
 export const GLOBAL_RATE_LIMIT = getRequiredInt('GLOBAL_RATE_LIMIT', 1000);
-export const PER_KEY_RATE_LIMIT = getRequiredInt('PER_KEY_RATE_LIMIT', 100);
 
 // Logging
 export const LOG_LEVEL = process.env.LOG_LEVEL || (IS_PRODUCTION ? 'info' : 'debug');

--- a/src/controllers/internal.controller.ts
+++ b/src/controllers/internal.controller.ts
@@ -1,0 +1,56 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { provisionApiKey } from '../services/provisioning.service';
+import { PROVISION_SECRET } from '../config/env';
+import { InvalidEmailError, ProvisionSecretInvalidError } from '../errors';
+import { ApiKeyEnvironment } from '../types';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type ProvisionBody = {
+  email: string;
+  name: string;
+  tier: 'FREE' | 'PRO' | 'ENTERPRISE';
+  environment: 'dev' | 'prod';
+};
+
+export async function provisionHandler(request: FastifyRequest<{ Body: ProvisionBody }>, reply: FastifyReply) {
+  const secret = request.headers['x-provision-secret'];
+  if (!secret || secret !== PROVISION_SECRET) {
+    throw new ProvisionSecretInvalidError();
+  }
+
+  const { email, name, tier, environment } = request.body;
+
+  if (!email || !EMAIL_REGEX.test(email)) {
+    throw new InvalidEmailError();
+  }
+
+  if (environment !== 'dev' && environment !== 'prod') {
+    reply.status(400).send({ error: 'BadRequestError', message: 'Environment must be dev or prod' });
+    return;
+  }
+
+  if (tier !== 'FREE' && tier !== 'PRO' && tier !== 'ENTERPRISE') {
+    reply.status(400).send({ error: 'BadRequestError', message: 'Tier must be FREE, PRO, or ENTERPRISE' });
+    return;
+  }
+
+  const { rawKey } = await provisionApiKey({
+    email,
+    name,
+    tier,
+    environment,
+  });
+
+  request.log.info({
+    event: 'api_key_provisioned',
+    email,
+    tier,
+    environment,
+  });
+
+  return {
+    apiKey: rawKey,
+    warning: 'Store this key securely. It will not be shown again.',
+  };
+}

--- a/src/db/migrations/009_internal_api_key_provisioning.sql
+++ b/src/db/migrations/009_internal_api_key_provisioning.sql
@@ -1,0 +1,12 @@
+-- Remove usage_count and rate_limit from api_keys
+ALTER TABLE api_keys DROP COLUMN IF EXISTS usage_count;
+ALTER TABLE api_keys DROP COLUMN IF EXISTS rate_limit;
+
+-- Add email column (required)
+-- Set default value for existing rows, then drop default
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS email TEXT DEFAULT 'system@example.com';
+ALTER TABLE api_keys ALTER COLUMN email DROP DEFAULT;
+ALTER TABLE api_keys ALTER COLUMN email SET NOT NULL;
+
+-- Add partial unique constraint for email
+CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_email_active ON api_keys(email) WHERE is_active = true;

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -193,6 +193,45 @@ export class InvalidPageContentError extends ApiError {
 }
 
 /**
+ * Provision Secret Invalid Error
+ * Thrown when the X-Provision-Secret header doesn't match the required env var.
+ */
+export class ProvisionSecretInvalidError extends ApiError {
+  readonly statusCode = 403;
+
+  constructor(message = 'Invalid provision secret') {
+    super(message);
+    this.name = 'PROVISION_SECRET_INVALID';
+  }
+}
+
+/**
+ * Invalid Email Error
+ * Thrown when an invalid email is provided during provisioning.
+ */
+export class InvalidEmailError extends ApiError {
+  readonly statusCode = 400;
+
+  constructor(message = 'Invalid email address provided') {
+    super(message);
+    this.name = 'INVALID_EMAIL';
+  }
+}
+
+/**
+ * API Key Already Exists Error
+ * Thrown if there is already an active key for the given email.
+ */
+export class ApiKeyAlreadyExistsError extends ApiError {
+  readonly statusCode = 409;
+
+  constructor(message = 'An active API key already exists for this email') {
+    super(message);
+    this.name = 'API_KEY_ALREADY_EXISTS';
+  }
+}
+
+/**
  * Type guard to check if an error is a custom API error
  */
 export function isApiError(error: unknown): error is ApiError {

--- a/src/plugins/apiKeyAuth.ts
+++ b/src/plugins/apiKeyAuth.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import fp from 'fastify-plugin';
-import { findApiKeyByRawKey, incrementUsage } from '../repositories/apiKey.repository';
-import { NODE_ENV, PER_KEY_RATE_LIMIT } from '../config';
+import { findApiKeyByRawKey, incrementMonthlyUsage } from '../repositories/apiKey.repository';
+import { NODE_ENV } from '../config';
 import { AuthErrorResponse } from '../types';
 
 /**
@@ -89,22 +89,16 @@ async function apiKeyAuthHook(request: FastifyRequest, reply: FastifyReply): Pro
     return;
   }
 
-  // Check rate limit
-  // System-wide PER_KEY_RATE_LIMIT caps the individual key's limit if it's more restrictive
-  const effectiveLimit = Math.min(apiKey.rateLimit, PER_KEY_RATE_LIMIT);
-  
-  if (apiKey.usageCount >= effectiveLimit) {
-    sendAuthError(reply, 429, 'Too Many Requests', 'Rate limit exceeded');
+  // Increment monthly usage atomically and check quota
+  const isUnderQuota = await incrementMonthlyUsage(apiKey.id);
+
+  if (!isUnderQuota) {
+    sendAuthError(reply, 403, 'Forbidden', 'Monthly usage limit reached');
     return;
   }
 
   // Attach API key to request for downstream handlers
   request.apiKey = apiKey;
-
-  // Increment usage count
-  // Note: This happens before the request completes. For billing accuracy,
-  // consider incrementing only on successful responses (in onResponse hook)
-  await incrementUsage(apiKey.id);
 }
 
 /**

--- a/src/repositories/apiKey.repository.ts
+++ b/src/repositories/apiKey.repository.ts
@@ -1,5 +1,5 @@
 import { DB } from '../db';
-import { ApiKey, ApiKeyRow, ApiKeyEnvironment } from '../types';
+import { ApiKey, ApiKeyRow, ApiKeyEnvironment, CreateApiKeyInput } from '../types';
 import { hashApiKey } from '../utils/apiKey';
 
 /**
@@ -10,10 +10,10 @@ function rowToApiKey(row: ApiKeyRow): ApiKey {
     id: row.id,
     keyHash: row.key_hash,
     name: row.name,
-    environment: row.environment,
+    email: row.email,
+    // Map DB 'live' to App 'prod' to handle legacy/mismatched DB constraints
+    environment: (row.environment as string) === 'live' ? 'prod' : (row.environment as ApiKeyEnvironment),
     isActive: row.is_active,
-    usageCount: row.usage_count,
-    rateLimit: row.rate_limit,
     createdAt: row.created_at,
     tier: row.tier,
     monthlyQuota: row.monthly_quota,
@@ -28,7 +28,7 @@ function rowToApiKey(row: ApiKeyRow): ApiKey {
  */
 export async function findApiKeyByHash(keyHash: string): Promise<ApiKey | null> {
   const result = await DB.query<ApiKeyRow>(
-    `SELECT id, key_hash, name, environment, is_active, usage_count, rate_limit,
+    `SELECT id, key_hash, name, email, environment, is_active,
             created_at, tier, monthly_quota, monthly_usage, quota_reset_at
      FROM api_keys
      WHERE key_hash = $1`,
@@ -52,11 +52,19 @@ export async function findApiKeyByRawKey(rawKey: string): Promise<ApiKey | null>
 }
 
 /**
- * Increment usage count for an API key
+ * Increment monthly usage count for an API key securely (atomic).
  * Called after each successful authenticated request
+ * Returns true if successfully incremented (under quota), false if out of quota.
  */
-export async function incrementUsage(keyId: number): Promise<void> {
-  await DB.query('UPDATE api_keys SET usage_count = usage_count + 1 WHERE id = $1', [keyId]);
+export async function incrementMonthlyUsage(keyId: number): Promise<boolean> {
+  const result = await DB.query(
+    `UPDATE api_keys
+     SET monthly_usage = monthly_usage + 1
+     WHERE id = $1 AND monthly_usage < monthly_quota
+     RETURNING id`,
+    [keyId],
+  );
+  return result.rowCount !== null && result.rowCount > 0;
 }
 
 /**
@@ -66,22 +74,18 @@ export async function incrementUsage(keyId: number): Promise<void> {
  * @param rawKey - The raw API key (will be hashed)
  * @param name - Human-readable name for the key
  * @param environment - 'dev' or 'prod'
- * @param rateLimit - Optional custom rate limit (default: 100)
  */
-export async function createApiKey(
-  rawKey: string,
-  name: string,
-  environment: ApiKeyEnvironment,
-  rateLimit: number = 100,
-): Promise<ApiKey> {
+export async function createApiKey(rawKey: string, name: string, environment: ApiKeyEnvironment): Promise<ApiKey> {
   const keyHash = hashApiKey(rawKey);
+  // Map App 'prod' to DB 'live'
+  const dbEnv = environment === 'prod' ? 'live' : environment;
 
   const result = await DB.query<ApiKeyRow>(
-    `INSERT INTO api_keys (key_hash, name, environment, rate_limit, tier, monthly_quota, monthly_usage, quota_reset_at)
-     VALUES ($1, $2, $3, $4, 'FREE', 100, 0, NOW())
-     RETURNING id, key_hash, name, environment, is_active, usage_count, rate_limit,
+    `INSERT INTO api_keys (key_hash, name, email, environment, tier, monthly_quota, monthly_usage, quota_reset_at)
+     VALUES ($1, $2, 'legacy@example.com', $3, 'FREE', 100, 0, NOW())
+     RETURNING id, key_hash, name, email, environment, is_active,
                created_at, tier, monthly_quota, monthly_usage, quota_reset_at`,
-    [keyHash, name, environment, rateLimit],
+    [keyHash, name, dbEnv],
   );
 
   return rowToApiKey(result.rows[0]);
@@ -95,9 +99,46 @@ export async function deactivateApiKey(keyId: number): Promise<void> {
 }
 
 /**
- * Reset usage count for an API key
- * Useful for billing cycle resets
+ * Find an active API key by email
  */
-export async function resetUsageCount(keyId: number): Promise<void> {
-  await DB.query('UPDATE api_keys SET usage_count = 0 WHERE id = $1', [keyId]);
+export async function findActiveByEmail(email: string): Promise<ApiKey | null> {
+  const result = await DB.query<ApiKeyRow>(
+    `SELECT id, key_hash, name, email, environment, is_active,
+            created_at, tier, monthly_quota, monthly_usage, quota_reset_at
+     FROM api_keys
+     WHERE email = $1 AND is_active = TRUE`,
+    [email],
+  );
+
+  if (result.rows.length === 0) {
+    return null;
+  }
+
+  return rowToApiKey(result.rows[0]);
+}
+
+/**
+ * Insert a provisioned key
+ * Note: Performs NO hashing or logic, only executes SQL.
+ */
+export async function insertProvisionedKey(
+  keyHash: string,
+  input: CreateApiKeyInput,
+  quotaResetAt: Date,
+): Promise<ApiKey> {
+  // Map App 'prod' to DB 'live'
+  const dbEnv = input.environment === 'prod' ? 'live' : input.environment;
+
+  const result = await DB.query<ApiKeyRow>(
+    `INSERT INTO api_keys (
+       key_hash, name, email, environment, tier,
+       monthly_quota, monthly_usage, quota_reset_at, is_active
+     )
+     VALUES ($1, $2, $3, $4, $5, $6, 0, $7, TRUE)
+     RETURNING id, key_hash, name, email, environment, is_active,
+               created_at, tier, monthly_quota, monthly_usage, quota_reset_at`,
+    [keyHash, input.name, input.email, dbEnv, input.tier, input.monthlyQuota, quotaResetAt],
+  );
+
+  return rowToApiKey(result.rows[0]);
 }

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -1,6 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { getInternalMetrics } from '../repositories/metrics.repository';
 import { INTERNAL_METRICS_TOKEN } from '../config';
+import { provisionHandler } from '../controllers/internal.controller';
 
 /**
  * Internal routes for metrics and system observability
@@ -26,4 +27,12 @@ export async function internalRoutes(fastify: FastifyInstance) {
     const metrics = await getInternalMetrics();
     reply.send(metrics);
   });
+
+  /**
+   * POST /v1/internal/provision
+   *
+   * Protected by X-Provision-Secret header.
+   * Provisions a new API key.
+   */
+  fastify.post('/internal/provision', provisionHandler);
 }

--- a/src/services/provisioning.service.ts
+++ b/src/services/provisioning.service.ts
@@ -1,0 +1,42 @@
+import crypto from 'crypto';
+import { findActiveByEmail, insertProvisionedKey } from '../repositories/apiKey.repository';
+import { getTierConfig } from '../config/tierConfig';
+import { ApiKeyEnvironment, CreateApiKeyInput } from '../types';
+import { ApiKeyAlreadyExistsError, InvalidEmailError } from '../errors';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function provisionApiKey(input: {
+  email: string;
+  name: string;
+  tier: 'FREE' | 'PRO' | 'ENTERPRISE';
+  environment: ApiKeyEnvironment;
+}): Promise<{ rawKey: string }> {
+  if (!input.email || !EMAIL_REGEX.test(input.email)) {
+    throw new InvalidEmailError();
+  }
+
+  const existingKey = await findActiveByEmail(input.email);
+  if (existingKey) {
+    throw new ApiKeyAlreadyExistsError();
+  }
+
+  const rawBytes = crypto.randomBytes(32).toString('hex');
+  const prefix = input.environment === 'dev' ? 'pd_dev_' : 'pd_live_';
+  const rawKey = `${prefix}${rawBytes}`;
+
+  const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
+  const tierConfig = getTierConfig(input.tier);
+
+  const now = new Date();
+  const quotaResetAt = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1, 0, 0, 0, 0));
+
+  const dbInput: CreateApiKeyInput = {
+    ...input,
+    monthlyQuota: tierConfig.monthlyQuota,
+  };
+
+  await insertProvisionedKey(keyHash, dbInput, quotaResetAt);
+
+  return { rawKey };
+}

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -8,10 +8,9 @@ export type ApiKey = {
   id: number;
   keyHash: string;
   name: string;
+  email: string;
   environment: ApiKeyEnvironment;
   isActive: boolean;
-  usageCount: number;
-  rateLimit: number;
   createdAt: Date;
   tier: 'FREE' | 'PRO' | 'ENTERPRISE';
   monthlyQuota: number;
@@ -23,15 +22,22 @@ export type ApiKeyRow = {
   id: number;
   key_hash: string;
   name: string;
+  email: string;
   environment: ApiKeyEnvironment;
   is_active: boolean;
-  usage_count: number;
-  rate_limit: number;
   created_at: Date;
-   tier: 'FREE' | 'PRO' | 'ENTERPRISE';
-   monthly_quota: number;
-   monthly_usage: number;
-   quota_reset_at: Date;
+  tier: 'FREE' | 'PRO' | 'ENTERPRISE';
+  monthly_quota: number;
+  monthly_usage: number;
+  quota_reset_at: Date;
+};
+
+export type CreateApiKeyInput = {
+  email: string;
+  name: string;
+  tier: 'FREE' | 'PRO' | 'ENTERPRISE';
+  environment: ApiKeyEnvironment;
+  monthlyQuota: number;
 };
 
 export type AuthErrorResponse = {


### PR DESCRIPTION
_Added deterministic internal API key provisioning endpoint_

- Added POST /v1/internal/provision (gated by PROVISION_SECRET)
- Enforced one active API key per email
- Removed usage_count column and related rate-limit logic
- Cleaned quota enforcement to rely solely on monthly_quota
- Added strict validation and typed flow
- Updated README documentation