### PR TITLE
Adds internal POST /v1/internal/snapshot endpoint to capture raw HTML snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,6 +728,45 @@ Before deployment:
 - Run replay validation with ≥20 runs each
 - Deployment blocked on any failure
 
+### Capturing Snapshots
+
+Snapshots can be captured internally using:
+
+```
+POST /v1/internal/snapshot
+```
+
+This endpoint:
+- Fetches raw HTML using the production fetch pipeline (timeout, redirect, and content validation all apply)
+- Stores the canonical URL and raw HTML in `replay_snapshots`
+- Returns the generated `snapshot_id`
+
+> **Note**: This endpoint is intended for development validation and pre-deployment capture only. It must never be used in automated client-facing workflows.
+
+**Example:**
+
+```sh
+curl -X POST http://localhost:3000/v1/internal/snapshot \
+  -H "Content-Type: application/json" \
+  -H "X-Internal-Token: <token>" \
+  -d '{"url":"https://example.com/privacy"}'
+```
+
+**Response:**
+
+```json
+{
+  "snapshot_id": "123e4567-e89b-12d3-a456-426614174000",
+  "url": "https://example.com/privacy"
+}
+```
+
+After capturing, use the `snapshot_id` with the replay validation CLI or endpoint:
+
+```sh
+npx ts-node scripts/replay-validate.ts 123e4567-e89b-12d3-a456-426614174000 20
+```
+
 This implementation only helps the developers and system operators directly. It is an internal quality assurance tool, not a feature for end-users.
 
 ## 17. Roadmap

--- a/src/controllers/internal.controller.ts
+++ b/src/controllers/internal.controller.ts
@@ -1,9 +1,9 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { provisionApiKey } from '../services/provisioning.service';
 import { validateSnapshotDeterminism } from '../services/replayValidator.service';
+import { captureReplaySnapshot } from '../services/replaySnapshot.service';
 import { PROVISION_SECRET } from '../config';
-import { InvalidEmailError, ProvisionSecretInvalidError } from '../errors';
-// import { ApiKeyEnvironment } from '../types';
+import { InvalidEmailError, ProvisionSecretInvalidError, BadRequestError } from '../errors';
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -66,4 +66,39 @@ export async function replayHandler(request: FastifyRequest<{ Params: { snapshot
   } catch (err: unknown) {
     reply.status(500).send({ error: 'NON_DETERMINISTIC_PIPELINE_DETECTED' });
   }
+}
+
+/**
+ * POST /v1/internal/snapshot
+ *
+ * Fetches a live policy page and stores its raw HTML in the replay_snapshots table.
+ * Used exclusively for pre-deployment determinism captures.
+ *
+ * Protected by X-Internal-Token.
+ * No quota enforcement, no job creation, no analysis pipeline.
+ */
+export async function createSnapshotController(
+  request: FastifyRequest<{ Body: { url: string } }>,
+  reply: FastifyReply,
+): Promise<void> {
+  const body: unknown = request.body;
+
+  if (
+    !body ||
+    typeof body !== 'object' ||
+    !('url' in body) ||
+    typeof (body as { url: unknown }).url !== 'string' ||
+    !(body as { url: string }).url.trim()
+  ) {
+    throw new BadRequestError('Missing or invalid "url" field in request body');
+  }
+
+  const { url } = body as { url: string };
+
+  const { snapshotId, canonicalUrl } = await captureReplaySnapshot(url);
+
+  reply.send({
+    snapshot_id: snapshotId,
+    url: canonicalUrl,
+  });
 }

--- a/src/repositories/replaySnapshot.repository.ts
+++ b/src/repositories/replaySnapshot.repository.ts
@@ -15,3 +15,19 @@ export async function getSnapshotRawHtml(id: string): Promise<string | null> {
 
   return result.rows[0].raw_html;
 }
+
+/**
+ * Insert a new replay snapshot into the database
+ *
+ * @param url - Canonicalized URL of the page
+ * @param rawHtml - Raw HTML content fetched from the page
+ * @returns Generated snapshot UUID
+ */
+export async function createReplaySnapshot(url: string, rawHtml: string): Promise<{ id: string }> {
+  const result = await DB.query<{ id: string }>(
+    'INSERT INTO replay_snapshots (url, raw_html) VALUES ($1, $2) RETURNING id',
+    [url, rawHtml],
+  );
+
+  return { id: result.rows[0].id };
+}

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { getInternalMetrics } from '../repositories/metrics.repository';
 import { INTERNAL_METRICS_TOKEN } from '../config';
-import { provisionHandler, replayHandler } from '../controllers/internal.controller';
+import { provisionHandler, replayHandler, createSnapshotController } from '../controllers/internal.controller';
 
 /**
  * Internal routes for metrics and system observability
@@ -54,5 +54,26 @@ export async function internalRoutes(fastify: FastifyInstance) {
 
     // Call the handler manually or pass it normally
     return replayHandler(request as Parameters<typeof replayHandler>[0], reply);
+  });
+
+  /**
+   * POST /v1/internal/snapshot
+   *
+   * Fetches a policy page and stores its raw HTML in replay_snapshots.
+   * Protected by X-Internal-Token header.
+   * Intended for pre-deployment determinism captures only.
+   */
+  fastify.post('/internal/snapshot', async (request, reply) => {
+    const token = request.headers['x-internal-token'];
+
+    if (!token || token !== INTERNAL_METRICS_TOKEN) {
+      reply.code(401).send({
+        error: 'Unauthorized',
+        message: 'Invalid or missing internal token',
+      });
+      return;
+    }
+
+    return createSnapshotController(request as Parameters<typeof createSnapshotController>[0], reply);
   });
 }

--- a/src/services/replaySnapshot.service.ts
+++ b/src/services/replaySnapshot.service.ts
@@ -1,0 +1,41 @@
+import { canonicalizeUrl } from '../utils/canonicalizeUrl';
+import { fetchPage } from '../utils/fetchPage';
+import { createReplaySnapshot } from '../repositories/replaySnapshot.repository';
+
+export type CaptureReplaySnapshotResult = {
+  snapshotId: string;
+  canonicalUrl: string;
+};
+
+/**
+ * Fetches a page by URL and stores its raw HTML in the replay_snapshots table.
+ *
+ * Flow:
+ * 1. Canonicalize the URL
+ * 2. Fetch raw HTML via the production fetch pipeline (timeout, redirect, validation included)
+ * 3. Persist canonicalUrl + rawHtml via repository
+ * 4. Return the snapshot ID and canonical URL
+ *
+ * STRICT:
+ * - No risk analysis
+ * - No section extraction
+ * - No hashing
+ * - No masking
+ * - Stores raw HTML only
+ * - Propagates ApiError types from fetch/canonicalize on failure
+ *
+ * @param url - Raw URL from request body
+ * @returns Snapshot ID and canonicalized URL
+ */
+export async function captureReplaySnapshot(url: string): Promise<CaptureReplaySnapshotResult> {
+  const canonicalUrl = canonicalizeUrl(url);
+
+  const rawHtml = await fetchPage(canonicalUrl);
+
+  const { id } = await createReplaySnapshot(canonicalUrl, rawHtml);
+
+  return {
+    snapshotId: id,
+    canonicalUrl,
+  };
+}

--- a/src/utils/fetchPage.ts
+++ b/src/utils/fetchPage.ts
@@ -48,6 +48,7 @@ export async function fetchPage(url: string, signal?: AbortSignal): Promise<stri
 
         // Specialized handling for blocking
         if (status === 403 || status === 429) {
+          // console.log('something gonna wrong');
           throw new PageAccessBlockedError();
         }
 


### PR DESCRIPTION
### Adds internal POST /v1/internal/snapshot endpoint to capture raw HTML snapshots for deterministic replay validation.

Features:
- Protected by X-Internal-Token
- Uses existing deterministic fetch pipeline
- Stores canonicalized URL + raw HTML
- Returns snapshotId
- No impact to monitoring jobs or quota system

_Improves replay validation workflow by allowing controlled snapshot capture._