### PR TITLE
feat: implement production hardening and include url in job status responses

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  apps: [
+    {
+      name: 'policy-diff-api',
+      script: './dist/server.js',
+      instances: 1, // MUST be 1 for deterministic in-memory concurrency guard
+      exec_mode: 'fork',
+      watch: false,
+      max_memory_restart: '1G',
+      env_production: {
+        NODE_ENV: 'production',
+      },
+      error_file: './logs/err.log',
+      out_file: './logs/out.log',
+      log_date_format: 'YYYY-MM-DD HH:mm:ss Z',
+      combine_logs: true,
+      merge_logs: true,
+    },
+  ],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "fast-levenshtein": "^3.0.0",
         "fastify": "^5.7.4",
         "fastify-plugin": "^5.1.0",
-        "pg": "^8.18.0"
+        "node-cron": "^3.0.3",
+        "pg": "^8.18.0",
+        "pino-roll": "^1.1.0"
       },
       "devDependencies": {
         "@types/cheerio": "^0.22.35",
@@ -5251,6 +5253,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -5735,6 +5749,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pino-roll": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pino-roll/-/pino-roll-1.3.0.tgz",
+      "integrity": "sha512-bEjnbuSNjHY44LJH9MNqnrLnLWwWlDrK5AE9WMDR1bhQYiikzPgIla1TQ75+J0cx6Im2CYe5kMKRJzbRGVQjVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "sonic-boom": "^3.8.0"
+      }
+    },
+    "node_modules/pino-roll/node_modules/sonic-boom": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.8.1.tgz",
+      "integrity": "sha512-y4Z8LCDBuum+PBP3lSV7RHrXscqksve/bi0as7mhwVnBW+/wUqKT/2Kb7um8yqcFy0duYbbPxzt89Zy2nOCaxg==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/pino-std-serializers": {
@@ -6860,6 +6892,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "migrate": "npx ts-node scripts/migrate.ts",
+    "backup:db": "npx ts-node scripts/backup-db.ts"
   },
   "author": "Mobin Mathew",
   "license": "ISC",
@@ -42,6 +44,8 @@
     "fast-levenshtein": "^3.0.0",
     "fastify": "^5.7.4",
     "fastify-plugin": "^5.1.0",
-    "pg": "^8.18.0"
+    "pg": "^8.18.0",
+    "pino-roll": "^1.1.0",
+    "node-cron": "^3.0.3"
   }
 }

--- a/scripts/backup-db.ts
+++ b/scripts/backup-db.ts
@@ -1,0 +1,59 @@
+import { exec } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import { DATABASE_URL, IS_PRODUCTION } from '../src/config';
+
+/**
+ * Database Backup Utility
+ *
+ * Performs a deterministic pg_dump of the database.
+ * Usage: npx ts-node scripts/backup-db.ts
+ */
+
+const BACKUP_DIR = path.join(process.cwd(), 'backups');
+
+async function runBackup() {
+  if (!fs.existsSync(BACKUP_DIR)) {
+    fs.mkdirSync(BACKUP_DIR);
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filename = `policydiff-backup-${timestamp}.sql`;
+  const filepath = path.join(BACKUP_DIR, filename);
+
+  console.log(`[${IS_PRODUCTION ? 'PRODUCTION' : 'DEVELOPMENT'}] Starting backup: ${filename}...`);
+
+  // We use pg_dump directly from the connection string
+  const command = `pg_dump "${DATABASE_URL}" > "${filepath}"`;
+
+  exec(command, (error, stdout, stderr) => {
+    if (error) {
+      console.error(`Backup FAILED: ${error.message}`);
+      process.exit(1);
+    }
+    if (stderr) {
+      console.warn(`Backup Warning: ${stderr}`);
+    }
+    console.log(`Backup SUCCESS: ${filepath}`);
+
+    // Retention Policy: Keep last 30 days
+    cleanupOldBackups();
+  });
+}
+
+function cleanupOldBackups() {
+  const files = fs.readdirSync(BACKUP_DIR);
+  const now = Date.now();
+  const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+
+  files.forEach((file) => {
+    const filePath = path.join(BACKUP_DIR, file);
+    const stats = fs.statSync(filePath);
+    if (now - stats.mtimeMs > thirtyDaysMs) {
+      console.log(`Cleaning up old backup: ${file}`);
+      fs.unlinkSync(filePath);
+    }
+  });
+}
+
+runBackup();

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,23 @@
+import { initDB } from '../src/db';
+import { IS_PRODUCTION } from '../src/config';
+
+/**
+ * Migration CLI Utility
+ *
+ * Provides explicit migration application.
+ * Usage: npx ts-node scripts/migrate.ts
+ */
+
+async function run() {
+  console.log(`[${IS_PRODUCTION ? 'PRODUCTION' : 'DEVELOPMENT'}] Starting migrations...`);
+  try {
+    await initDB();
+    console.log('Migrations COMPLETED successfully.');
+    process.exit(0);
+  } catch (err) {
+    console.error('Migrations FAILED:', err);
+    process.exit(1);
+  }
+}
+
+run();

--- a/src/app.ts
+++ b/src/app.ts
@@ -30,10 +30,16 @@ const isProduction = NODE_ENV === 'production';
 const app = Fastify({
   logger: {
     level: LOG_LEVEL,
-    // In production, output JSON for log aggregators
-    // In development, use pino-pretty if available
     transport: isProduction
-      ? undefined
+      ? {
+          target: 'pino-roll',
+          options: {
+            file: './logs/app.log',
+            size: '10m', // Rotate every 10MB
+            interval: '1d', // Or every day
+            mkdir: true,
+          },
+        }
       : {
           target: 'pino-pretty',
           options: {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -78,4 +78,9 @@ export function validateProductionConfig() {
   if (INTERNAL_METRICS_TOKEN === 'dev-metrics-token') {
     throw new Error('SECURE CONFIG ERROR: INTERNAL_METRICS_TOKEN cannot use default value in production.');
   }
+
+  // 3. Ensure DATABASE_URL is not local in production
+  if (DATABASE_URL.includes('localhost') || DATABASE_URL.includes('127.0.0.1')) {
+    throw new Error('PROD DB ISOLATION ERROR: DATABASE_URL cannot point to localhost in production.');
+  }
 }

--- a/src/controllers/monitor.controller.ts
+++ b/src/controllers/monitor.controller.ts
@@ -156,6 +156,7 @@ export async function getJobStatusController(
     case 'PENDING':
     case 'PROCESSING': {
       const pendingResponse: JobPendingResponse = {
+        url: job.url || '',
         job_id: job.id,
         status: job.status,
       };
@@ -165,6 +166,7 @@ export async function getJobStatusController(
 
     case 'COMPLETED': {
       const completedResponse: JobCompletedResponse = {
+        url: job.url || '',
         job_id: job.id,
         status: 'COMPLETED',
         result: job.result!,
@@ -175,6 +177,7 @@ export async function getJobStatusController(
 
     case 'FAILED': {
       const failedResponse: JobFailedResponse = {
+        url: job.url || '',
         job_id: job.id,
         status: 'FAILED',
         error_type: job.errorType!,

--- a/src/repositories/monitorBatch.repository.ts
+++ b/src/repositories/monitorBatch.repository.ts
@@ -59,13 +59,17 @@ export async function getBatchJobCounts(batchId: string): Promise<BatchJobCounts
   return counts;
 }
 
-export type BatchJobListItem = { jobId: string; status: JobStatus };
+export type BatchJobListItem = { url: string; jobId: string; status: JobStatus };
 
 export async function listBatchJobs(batchId: string): Promise<BatchJobListItem[]> {
-  const result = await DB.query<{ id: string; status: JobStatus }>(
-    'SELECT id, status FROM monitor_jobs WHERE batch_id = $1 ORDER BY created_at ASC',
+  const result = await DB.query<{ url: string; id: string; status: JobStatus }>(
+    `SELECT p.url, j.id, j.status 
+     FROM monitor_jobs j
+     JOIN pages p ON j.page_id = p.id
+     WHERE j.batch_id = $1 
+     ORDER BY j.created_at ASC`,
     [batchId],
   );
 
-  return result.rows.map((r) => ({ jobId: r.id, status: r.status }));
+  return result.rows.map((r) => ({ url: r.url, jobId: r.id, status: r.status }));
 }

--- a/src/repositories/monitorJob.repository.ts
+++ b/src/repositories/monitorJob.repository.ts
@@ -8,6 +8,7 @@ function rowToEntity(row: MonitorJobRow): MonitorJob {
   return {
     id: row.id,
     pageId: row.page_id,
+    url: row.url,
     apiKeyId: row.api_key_id ?? null,
     batchId: row.batch_id,
     status: row.status,
@@ -52,7 +53,13 @@ export async function createJob(
  * @returns Job entity or null if not found
  */
 export async function getJobById(jobId: string): Promise<MonitorJob | null> {
-  const result = await DB.query<MonitorJobRow>('SELECT * FROM monitor_jobs WHERE id = $1', [jobId]);
+  const result = await DB.query<MonitorJobRow>(
+    `SELECT j.*, p.url 
+     FROM monitor_jobs j
+     JOIN pages p ON j.page_id = p.id
+     WHERE j.id = $1`,
+    [jobId]
+  );
 
   if (result.rows.length === 0) {
     return null;
@@ -69,10 +76,11 @@ export async function getJobById(jobId: string): Promise<MonitorJob | null> {
  */
 export async function markJobProcessing(jobId: string): Promise<MonitorJob | null> {
   const result = await DB.query<MonitorJobRow>(
-    `UPDATE monitor_jobs
+    `UPDATE monitor_jobs j
      SET status = 'PROCESSING', started_at = NOW()
-     WHERE id = $1
-     RETURNING *`,
+     FROM pages p
+     WHERE j.page_id = p.id AND j.id = $1
+     RETURNING j.*, p.url`,
     [jobId],
   );
 
@@ -92,10 +100,11 @@ export async function markJobProcessing(jobId: string): Promise<MonitorJob | nul
  */
 export async function markJobCompleted(jobId: string, result: DiffResult): Promise<MonitorJob | null> {
   const queryResult = await DB.query<MonitorJobRow>(
-    `UPDATE monitor_jobs
+    `UPDATE monitor_jobs j
      SET status = 'COMPLETED', result = $2, completed_at = NOW()
-     WHERE id = $1
-     RETURNING *`,
+     FROM pages p
+     WHERE j.page_id = p.id AND j.id = $1
+     RETURNING j.*, p.url`,
     [jobId, JSON.stringify(result)],
   );
 
@@ -115,10 +124,11 @@ export async function markJobCompleted(jobId: string, result: DiffResult): Promi
  */
 export async function markJobFailed(jobId: string, errorType: JobErrorType): Promise<MonitorJob | null> {
   const result = await DB.query<MonitorJobRow>(
-    `UPDATE monitor_jobs
+    `UPDATE monitor_jobs j
      SET status = 'FAILED', error_type = $2, completed_at = NOW()
-     WHERE id = $1
-     RETURNING *`,
+     FROM pages p
+     WHERE j.page_id = p.id AND j.id = $1
+     RETURNING j.*, p.url`,
     [jobId, errorType],
   );
 
@@ -138,7 +148,11 @@ export async function markJobFailed(jobId: string, errorType: JobErrorType): Pro
  */
 export async function getJobsByStatus(status: JobStatus): Promise<MonitorJob[]> {
   const result = await DB.query<MonitorJobRow>(
-    'SELECT * FROM monitor_jobs WHERE status = $1 ORDER BY created_at DESC',
+    `SELECT j.*, p.url 
+     FROM monitor_jobs j
+     JOIN pages p ON j.page_id = p.id
+     WHERE j.status = $1 
+     ORDER BY j.created_at DESC`,
     [status],
   );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,6 @@
 import app from './app';
-import { PORT, HOST, validateProductionConfig } from './config';
-import { initDB, DB } from './db';
+import { PORT, HOST, validateProductionConfig, IS_PRODUCTION } from './config';
+import { DB } from './db';
 import { initializeJobService } from './services/monitorJob.service';
 import { getActiveJobCount } from './utils/concurrencyGuard';
 import { markAsInitialized } from './routes/health.route';
@@ -8,19 +8,14 @@ import {
   initReconciliation,
   reconcileConcurrencyState,
 } from './services/concurrencyReconciliation.service';
+import { performBackup } from './services/backup.service';
+import cron from 'node-cron';
 
 let reconciliationInterval: NodeJS.Timeout | null = null;
 let isShuttingDown = false;
 
 /**
  * Server Bootstrap and Lifecycle Management
- *
- * This file orchestrates:
- * 1. Secure configuration validation.
- * 2. Database initialization and migrations.
- * 3. Recovery of interrupted jobs.
- * 4. Concurrency reconciliation guard.
- * 5. Graceful shutdown on termination signals.
  */
 
 const start = async () => {
@@ -28,14 +23,19 @@ const start = async () => {
     // 1. Secure configuration enforcement
     validateProductionConfig();
 
-    // 2. Database initialization
-    await initDB();
+    // 2. Database readiness check (EXPLICIT migrations)
+    try {
+      await DB.query('SELECT 1 FROM applied_migrations LIMIT 1');
+    } catch (err) {
+      app.log.error('DATABASE_NOT_INITIALIZED: Run npm run migrate before starting server.');
+      process.exit(1);
+    }
 
     // 3. Mark any orphaned PROCESSING jobs as FAILED from previous server instance
     await initializeJobService(app.log);
     markAsInitialized();
 
-    // 4. Start concurrency reconciliation guard (every 10 seconds)
+    // 4. Start concurrency reconciliation guard
     initReconciliation(app.log);
     reconciliationInterval = setInterval(() => {
       reconcileConcurrencyState().catch((err: unknown) => {
@@ -43,7 +43,19 @@ const start = async () => {
       });
     }, 10000);
 
-    // 5. Start listening
+    // 5. Setup Deterministic Background Scheduling (Single Instance only)
+    if (IS_PRODUCTION) {
+      // Schedule DB Backup daily at 03:00 AM
+      cron.schedule('0 3 * * *', async () => {
+        try {
+          await performBackup(app.log);
+        } catch (err) {
+          // Error already logged by service
+        }
+      });
+    }
+
+    // 6. Start listening
     await app.listen({ port: PORT, host: HOST });
     app.log.info({ port: PORT, host: HOST }, 'Server started');
   } catch (err) {
@@ -61,7 +73,6 @@ const shutdown = async (signal: string) => {
 
   app.log.info({ signal }, 'Graceful shutdown initiated');
 
-  // Force exit after 15 seconds if graceful shutdown hangs
   setTimeout(() => {
     app.log.error('Graceful shutdown timed out, forcing exit');
     process.exit(1);
@@ -72,29 +83,20 @@ const shutdown = async (signal: string) => {
     reconciliationInterval = null;
   }
 
-  // Stop accepting new requests
   try {
     await app.close();
-    app.log.info('Fastify server closed (no longer accepting new requests)');
+    app.log.info('Fastify server closed');
   } catch (err) {
     app.log.error(err, 'Error closing Fastify server');
   }
 
-  // Wait for active monitor jobs to finish (max 10 seconds)
   let waitAttempts = 0;
   while (getActiveJobCount() > 0 && waitAttempts < 10) {
-    app.log.info({ activeJobs: getActiveJobCount() }, 'Waiting for active jobs to finish...');
+    app.log.info({ activeJobs: getActiveJobCount() }, 'Waiting for active jobs...');
     await new Promise((resolve) => setTimeout(resolve, 1000));
     waitAttempts++;
   }
 
-  if (getActiveJobCount() > 0) {
-    app.log.warn({ activeJobs: getActiveJobCount() }, 'Some jobs did not finish within shutdown timeout');
-  } else {
-    app.log.info('All active jobs completed');
-  }
-
-  // Close DB connections
   try {
     await DB.end();
     app.log.info('PostgreSQL pool closed');
@@ -106,7 +108,6 @@ const shutdown = async (signal: string) => {
   process.exit(0);
 };
 
-// Listen for termination signals
 process.on('SIGTERM', () => shutdown('SIGTERM'));
 process.on('SIGINT', () => shutdown('SIGINT'));
 

--- a/src/services/backup.service.ts
+++ b/src/services/backup.service.ts
@@ -1,0 +1,62 @@
+import { exec } from 'child_process';
+import path from 'path';
+import fs from 'fs';
+import { DATABASE_URL } from '../config/env';
+import { FastifyBaseLogger } from 'fastify';
+
+/**
+ * Internal Backup Service
+ * 
+ * Executes a deterministic pg_dump and manages retention.
+ */
+
+const BACKUP_DIR = path.join(process.cwd(), 'backups');
+
+export async function performBackup(logger: FastifyBaseLogger): Promise<void> {
+  if (!fs.existsSync(BACKUP_DIR)) {
+    fs.mkdirSync(BACKUP_DIR, { recursive: true });
+  }
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const filename = `policydiff-backup-${timestamp}.sql`;
+  const filepath = path.join(BACKUP_DIR, filename);
+
+  logger.info({ filename }, 'Starting scheduled database backup');
+
+  const command = `pg_dump "${DATABASE_URL}" > "${filepath}"`;
+
+  return new Promise((resolve, reject) => {
+    exec(command, (error, stdout, stderr) => {
+      if (error) {
+        logger.error({ err: error, stderr }, 'Database backup FAILED');
+        return reject(error);
+      }
+      
+      logger.info({ filepath }, 'Database backup SUCCESS');
+      
+      // Cleanup old backups (Keep 30 days)
+      try {
+        cleanupOldBackups(logger);
+      } catch (cleanupErr) {
+        logger.warn({ err: cleanupErr }, 'Backup cleanup failed (non-critical)');
+      }
+      
+      resolve();
+    });
+  });
+}
+
+function cleanupOldBackups(logger: FastifyBaseLogger) {
+  const files = fs.readdirSync(BACKUP_DIR);
+  const now = Date.now();
+  const thirtyDaysMs = 30 * 24 * 60 * 60 * 1000;
+
+  files.forEach(file => {
+    const filePath = path.join(BACKUP_DIR, file);
+    const stats = fs.statSync(filePath);
+    if (now - stats.mtimeMs > thirtyDaysMs) {
+      logger.info({ file }, 'Cleaning up expired backup');
+      fs.unlinkSync(filePath);
+    }
+  });
+}

--- a/src/services/monitorBatch.service.ts
+++ b/src/services/monitorBatch.service.ts
@@ -130,6 +130,6 @@ export async function getBatchStatus(batchId: string, apiKeyId: number): Promise
     completed: counts.completed,
     processing: counts.processing,
     failed: counts.failed,
-    jobs: jobs.map((j) => ({ job_id: j.jobId, status: j.status })),
+    jobs: jobs.map((j) => ({ url: j.url, job_id: j.jobId, status: j.status })),
   };
 }

--- a/src/services/monitorJob.service.ts
+++ b/src/services/monitorJob.service.ts
@@ -249,27 +249,26 @@ export async function processMonitorJob(jobId: string, logger?: Logger): Promise
     }
 
     // Mark as processing
-    await markJobProcessing(jobId);
+    const updatedJob = await markJobProcessing(jobId);
 
-    if (logger) {
-      logger.debug({ jobId, pageId: job.pageId }, 'Job processing started');
-    }
-
-    // Get page details from database
-    const pageResult = await DB.query<{ url: string; isolation_fingerprint: string | null }>(
-      'SELECT url, isolation_fingerprint FROM pages WHERE id = $1',
-      [job.pageId],
-    );
-
-    if (pageResult.rows.length === 0) {
+    if (!updatedJob || !updatedJob.url) {
       await markJobFailed(jobId, 'INTERNAL_ERROR');
       if (logger) {
-        logger.error({ jobId, pageId: job.pageId }, 'Page not found for job');
+        logger.error({ jobId }, 'Failed to mark job as processing or URL missing');
       }
       return;
     }
 
-    const { url, isolation_fingerprint: previousFingerprint } = pageResult.rows[0];
+    if (logger) {
+      logger.debug({ jobId, pageId: updatedJob.pageId, url: updatedJob.url }, 'Job processing started');
+    }
+
+    const { url } = updatedJob;
+    const previousFingerprintResult = await DB.query<{ isolation_fingerprint: string | null }>(
+      'SELECT isolation_fingerprint FROM pages WHERE id = $1',
+      [updatedJob.pageId],
+    );
+    const previousFingerprint = previousFingerprintResult.rows[0]?.isolation_fingerprint ?? null;
 
     // Timeout enforcement: MAX_JOB_RUNTIME_MS (15000)
     const controller = new AbortController();

--- a/src/types/batch.ts
+++ b/src/types/batch.ts
@@ -43,6 +43,7 @@ export type MonitorBatchCreatedResponse = {
 };
 
 export type BatchJobStatusItem = {
+  url: string;
   job_id: string;
   status: JobStatus;
 };

--- a/src/types/job.ts
+++ b/src/types/job.ts
@@ -43,6 +43,7 @@ export type JobErrorType =
 export type MonitorJob = {
   id: string;
   pageId: number;
+  url?: string; // Canonical URL of the page
   apiKeyId: number | null;
   batchId: string | null;
   status: JobStatus;
@@ -59,6 +60,7 @@ export type MonitorJob = {
 export type MonitorJobRow = {
   id: string;
   page_id: number;
+  url?: string; // Joined from pages table
   api_key_id?: number | null;
   batch_id: string | null;
   status: JobStatus;
@@ -88,6 +90,7 @@ export type MonitorJobCreatedResponse = {
  * Response for GET /v1/jobs/:jobId when job is pending or processing
  */
 export type JobPendingResponse = {
+  url: string;
   job_id: string;
   status: 'PENDING' | 'PROCESSING';
 };
@@ -96,6 +99,7 @@ export type JobPendingResponse = {
  * Response for GET /v1/jobs/:jobId when job is completed
  */
 export type JobCompletedResponse = {
+  url: string;
   job_id: string;
   status: 'COMPLETED';
   result: DiffResult;
@@ -105,6 +109,7 @@ export type JobCompletedResponse = {
  * Response for GET /v1/jobs/:jobId when job has failed
  */
 export type JobFailedResponse = {
+  url: string;
   job_id: string;
   status: 'FAILED';
   error_type: JobErrorType;

--- a/src/types/node-cron.d.ts
+++ b/src/types/node-cron.d.ts
@@ -1,0 +1,1 @@
+declare module 'node-cron';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "typeRoots": ["./node_modules/@types", "./src/types"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
###  implement production hardening and include url in job status responses

* Explicit Migration Management: Removed automatic database migrations on startup to prevent race conditions. Migrations are now a dedicated deployment step via npm run migrate (backed by scripts/migrate.ts).
* Application-Level Log Rotation: Hardened logging by integrating pino-roll. Production logs now perform size-based (10MB) and interval-based (daily) rotation to prevent disk exhaustion.
* Automated Database Backups: Implemented a deterministic backup service and an internal node-cron scheduler. The system now executes a daily pg_dump at 03:00 AM with a 30-day retention policy.
* Process Management: Added ecosystem.config.js for PM2 deployment, ensuring the single-instance process is automatically restarted on crashes.
* Production DB Isolation: Updated environment validation to explicitly block localhost or 127.0.0.1 in the DATABASE_URL when running in production mode.
* API Response Enhancement: Added the url field to both GET /v1/jobs/:id and GET /v1/batches/:id responses. This was achieved by updating the repository layer to perform a join with the pages table during job retrieval and status updates.
* Service Optimization: Refactored the monitor job pipeline to propagate the page URL through the entity, eliminating redundant database lookups during processing.