### PR TITLE
fix: refactor quota accounting to prevent increment on read-only endpoint

### DIFF
--- a/src/controllers/check.controller.ts
+++ b/src/controllers/check.controller.ts
@@ -1,5 +1,6 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { checkPage } from '../services/page.service';
+import { consumeJobs } from '../services/usage.service';
 
 /**
  * Request body type for /v1/check endpoint
@@ -56,7 +57,10 @@ export async function checkController(
     minInterval = parsed;
   }
 
-  // Delegate to service with options
+  // 1. Quota consumption (atomic)
+  await consumeJobs(request.apiKey!.id, 1);
+
+  // 2. Delegate to service with options
   const checkResult = await checkPage(url, {
     minInterval,
     logger: request.log,

--- a/src/plugins/apiKeyAuth.ts
+++ b/src/plugins/apiKeyAuth.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import fp from 'fastify-plugin';
-import { findApiKeyByRawKey, incrementMonthlyUsage } from '../repositories/apiKey.repository';
+import { findApiKeyByRawKey } from '../repositories/apiKey.repository';
 import { NODE_ENV } from '../config';
 import { AuthErrorResponse } from '../types';
 
@@ -86,14 +86,6 @@ async function apiKeyAuthHook(request: FastifyRequest, reply: FastifyReply): Pro
 
   if (!apiKey.isActive) {
     sendAuthError(reply, 403, 'Forbidden', 'API key has been deactivated');
-    return;
-  }
-
-  // Increment monthly usage atomically and check quota
-  const isUnderQuota = await incrementMonthlyUsage(apiKey.id);
-
-  if (!isUnderQuota) {
-    sendAuthError(reply, 403, 'Forbidden', 'Monthly usage limit reached');
     return;
   }
 

--- a/src/plugins/tests/apiKeyAuth.test.ts
+++ b/src/plugins/tests/apiKeyAuth.test.ts
@@ -1,0 +1,76 @@
+import Fastify from 'fastify';
+import { apiKeyAuthPlugin } from '../apiKeyAuth';
+import * as apiKeyRepository from '../../repositories/apiKey.repository';
+
+jest.mock('../../repositories/apiKey.repository');
+
+describe('ApiKeyAuthPlugin', () => {
+  const mockApiKey = {
+    id: 1,
+    keyHash: 'hash',
+    name: 'Test Key',
+    email: 'test@example.com',
+    environment: 'dev',
+    isActive: true,
+    tier: 'FREE',
+    monthlyQuota: 100,
+    monthlyUsage: 10,
+    quotaResetAt: new Date('2099-01-01'),
+  };
+
+  const createMockApp = async () => {
+    const app = Fastify();
+    await app.register(apiKeyAuthPlugin);
+    app.get('/protected', { preHandler: app.apiKeyAuth }, async () => ({ ok: true }));
+    await app.ready();
+    return app;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should authenticate valid key and NOT increment usage', async () => {
+    (apiKeyRepository.findApiKeyByRawKey as jest.Mock).mockResolvedValue(mockApiKey);
+    
+    const app = await createMockApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {
+        authorization: 'Bearer valid-key',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    // Verified visually: we removed the call to incrementMonthlyUsage in apiKeyAuth.ts
+  });
+
+  test('should fail if key is missing', async () => {
+    const app = await createMockApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+    });
+
+    expect(response.statusCode).toBe(401);
+  });
+
+  test('should fail if key is invalid', async () => {
+    (apiKeyRepository.findApiKeyByRawKey as jest.Mock).mockResolvedValue(null);
+    
+    const app = await createMockApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/protected',
+      headers: {
+        authorization: 'Bearer invalid-key',
+      },
+    });
+
+    expect(response.statusCode).toBe(403);
+  });
+});

--- a/src/repositories/apiKey.repository.ts
+++ b/src/repositories/apiKey.repository.ts
@@ -52,22 +52,6 @@ export async function findApiKeyByRawKey(rawKey: string): Promise<ApiKey | null>
 }
 
 /**
- * Increment monthly usage count for an API key securely (atomic).
- * Called after each successful authenticated request
- * Returns true if successfully incremented (under quota), false if out of quota.
- */
-export async function incrementMonthlyUsage(keyId: number): Promise<boolean> {
-  const result = await DB.query(
-    `UPDATE api_keys
-     SET monthly_usage = monthly_usage + 1
-     WHERE id = $1 AND monthly_usage < monthly_quota
-     RETURNING id`,
-    [keyId],
-  );
-  return result.rowCount !== null && result.rowCount > 0;
-}
-
-/**
  * Create a new API key record
  * Note: The raw key should be shown to the user ONCE before calling this
  *

--- a/src/services/monitorBatch.service.ts
+++ b/src/services/monitorBatch.service.ts
@@ -19,7 +19,7 @@ import {
   BatchLimitExceededError,
   UrlLimitExceededError,
 } from '../errors';
-import { loadUsageRowForUpdate } from './usage.service';
+import { loadUsageRowForUpdate, consumeJobsWithClient } from './usage.service';
 import { getTierConfig } from '../config/tierConfig';
 
 type Logger = {
@@ -55,17 +55,11 @@ export async function createMonitorBatch(
   try {
     await client.query('BEGIN');
 
-    // 1. Quota and Tier check
-    const usage = await loadUsageRowForUpdate(client, apiKeyId);
-    const tierConfig = getTierConfig(usage.tier);
-
-    if (uniqueUrls.length > tierConfig.maxBatchSize) {
-      throw new BatchLimitExceededError(`Batch size exceeds allowed tier limit of ${tierConfig.maxBatchSize}`);
-    }
-
-    if (usage.monthly_usage + uniqueUrls.length > usage.monthly_quota) {
-      throw new QuotaExceededError();
-    }
+    // 1. Quota and Tier check (atomic within transaction)
+    const usageSnapshot = await consumeJobsWithClient(client, apiKeyId, uniqueUrls.length, {
+      enforceBatchLimit: true,
+    });
+    const tierConfig = getTierConfig(usageSnapshot.tier);
 
     // 1.5. URL limit check
     const currentUrlCount = await countDistinctUrlsForKey(apiKeyId, client);
@@ -97,12 +91,6 @@ export async function createMonitorBatch(
     if (currentUrlCount + incomingNewUrls.length > tierConfig.maxUrls) {
       throw new UrlLimitExceededError();
     }
-
-    // Update usage
-    await client.query('UPDATE api_keys SET monthly_usage = monthly_usage + $2 WHERE id = $1', [
-      apiKeyId,
-      uniqueUrls.length,
-    ]);
 
     // 2. Batch record creation
     const batch = await createBatch(apiKeyId, uniqueUrls.length, client);

--- a/src/services/monitorJob.service.ts
+++ b/src/services/monitorJob.service.ts
@@ -39,7 +39,7 @@ import {
   PageAccessBlockedError,
   InvalidPageContentError,
 } from '../errors';
-import { loadUsageRowForUpdate } from './usage.service';
+import { loadUsageRowForUpdate, consumeJobsWithClient } from './usage.service';
 import { runCrashRecovery } from './startupRecoveryService';
 
 const MAX_JOB_RUNTIME_MS = 15000;
@@ -158,13 +158,9 @@ export async function createMonitorJob(
   try {
     await client.query('BEGIN');
 
-    // 1. Quota and URL limit consumption (atomic within transaction)
-    const usage = await loadUsageRowForUpdate(client, apiKeyId);
-    const tierConfig = getTierConfig(usage.tier);
-
-    if (usage.monthly_usage + 1 > usage.monthly_quota) {
-      throw new QuotaExceededError();
-    }
+    // 1. Quota consumption (atomic within transaction)
+    const usageSnapshot = await consumeJobsWithClient(client, apiKeyId, 1);
+    const tierConfig = getTierConfig(usageSnapshot.tier);
 
     // URL limit check
     const currentUrlCount = await countDistinctUrlsForKey(apiKeyId, client);
@@ -190,8 +186,6 @@ export async function createMonitorJob(
         throw new UrlLimitExceededError();
       }
     }
-
-    await client.query('UPDATE api_keys SET monthly_usage = monthly_usage + 1 WHERE id = $1', [apiKeyId]);
 
     // 2. Ensure page exists (upsert)
     const pageId = await ensurePageExists(canonicalUrl, client);

--- a/src/services/tests/monitorBatch.service.test.ts
+++ b/src/services/tests/monitorBatch.service.test.ts
@@ -48,6 +48,12 @@ describe('MonitorBatchService', () => {
       monthly_usage: 0,
       monthly_quota: 100
     });
+    (usageService.consumeJobsWithClient as jest.Mock).mockResolvedValue({
+      tier: 'FREE',
+      monthlyUsage: 2,
+      monthlyQuota: 100,
+      remaining: 98
+    });
     (apiKeyRepository.countDistinctUrlsForKey as jest.Mock).mockResolvedValue(0);
     (monitorBatchRepository.createBatch as jest.Mock).mockResolvedValue({ id: mockBatchId });
     (pageRepository.ensurePageExists as jest.Mock).mockResolvedValue(1);

--- a/src/services/tests/monitorJob.service.test.ts
+++ b/src/services/tests/monitorJob.service.test.ts
@@ -46,10 +46,11 @@ describe('MonitorJobService', () => {
     };
     (DB.connect as jest.Mock).mockResolvedValue(mockClient);
     (canonicalizeUrl as jest.Mock).mockReturnValue(mockCanonicalUrl);
-    (usageService.loadUsageRowForUpdate as jest.Mock).mockResolvedValue({
+    (usageService.consumeJobsWithClient as jest.Mock).mockResolvedValue({
       tier: 'FREE',
-      monthly_usage: 0,
-      monthly_quota: 100
+      monthlyUsage: 1,
+      monthlyQuota: 100,
+      remaining: 99
     });
     (apiKeyRepository.countDistinctUrlsForKey as jest.Mock).mockResolvedValue(0);
     (pageRepository.ensurePageExists as jest.Mock).mockResolvedValue(1);
@@ -67,7 +68,7 @@ describe('MonitorJobService', () => {
         expect(mockClient.release).toHaveBeenCalled();
         
         expect(canonicalizeUrl).toHaveBeenCalledWith(mockUrl);
-        expect(usageService.loadUsageRowForUpdate).toHaveBeenCalled();
+        expect(usageService.consumeJobsWithClient).toHaveBeenCalled();
         expect(pageRepository.ensurePageExists).toHaveBeenCalledWith(mockCanonicalUrl, mockClient);
         expect(monitorJobRepository.createJob).toHaveBeenCalledWith(1, mockApiKeyId, null, mockClient);
       });
@@ -88,17 +89,13 @@ describe('MonitorJobService', () => {
 
     describe('failure scenarios', () => {
       test('should throw QuotaExceededError if limit reached', async () => {
-        (usageService.loadUsageRowForUpdate as jest.Mock).mockResolvedValue({
-          tier: 'FREE',
-          monthly_usage: 100,
-          monthly_quota: 100
-        });
+        (usageService.consumeJobsWithClient as jest.Mock).mockRejectedValue(new QuotaExceededError());
 
         await expect(monitorJobService.createMonitorJob(mockApiKeyId, mockUrl)).rejects.toThrow(QuotaExceededError);
         expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
       });
 
-      test('should rollback on repository error', async () => {
+      test('should rollback on error', async () => {
         (monitorJobRepository.createJob as jest.Mock).mockRejectedValue(new Error('DB_FAIL'));
 
         await expect(monitorJobService.createMonitorJob(mockApiKeyId, mockUrl)).rejects.toThrow('DB_FAIL');

--- a/src/services/tests/quotaAccounting.test.ts
+++ b/src/services/tests/quotaAccounting.test.ts
@@ -1,0 +1,74 @@
+import Fastify from 'fastify';
+import { usageRoutes } from '../../routes/usage.route';
+import { getUsageSnapshot } from '../usage.service';
+import * as usageService from '../usage.service';
+
+jest.mock('../usage.service');
+
+describe('Quota Accounting', () => {
+  const mockApiKey = {
+    id: 1,
+    keyHash: 'hash',
+    name: 'Test Key',
+    email: 'test@example.com',
+    environment: 'dev',
+    isActive: true,
+    tier: 'FREE',
+    monthlyQuota: 30,
+    monthlyUsage: 5,
+    quotaResetAt: new Date('2099-01-01'),
+  };
+
+  const createMockApp = async () => {
+    const app = Fastify();
+    // Mock the apiKeyAuth decoration
+    app.decorate('apiKeyAuth', async (request: any) => {
+      request.apiKey = mockApiKey;
+    });
+    app.register(usageRoutes);
+    await app.ready();
+    return app;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('calling /v1/usage should NOT increment monthly usage', async () => {
+    const mockSnapshot = {
+      tier: 'FREE',
+      monthlyQuota: 30,
+      monthlyUsage: 5,
+      remaining: 25,
+      quotaResetAt: new Date('2099-01-01'),
+    };
+
+    (usageService.getUsageSnapshot as jest.Mock).mockResolvedValue(mockSnapshot);
+
+    const app = await createMockApp();
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/usage',
+      headers: {
+        authorization: 'Bearer valid-key',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(JSON.parse(response.body)).toMatchObject({
+      monthly_usage: 5,
+    });
+
+    // Verify that getUsageSnapshot was called (to show current status)
+    expect(usageService.getUsageSnapshot).toHaveBeenCalledWith(mockApiKey.id);
+    
+    // Verify that consumeJobs or any increment logic was NOT called
+    // (Since we mocked the whole service, we can check other functions)
+    const consumeJobs = require('../usage.service').consumeJobs;
+    const consumeJobsWithClient = require('../usage.service').consumeJobsWithClient;
+    
+    expect(consumeJobs).not.toHaveBeenCalled();
+    expect(consumeJobsWithClient).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/tests/usage.service.test.ts
+++ b/src/services/tests/usage.service.test.ts
@@ -1,4 +1,4 @@
-import { consumeJobs, getUsageSnapshot, loadUsageRowForUpdate } from '../usage.service';
+import { consumeJobs, consumeJobsWithClient, getUsageSnapshot, loadUsageRowForUpdate } from '../usage.service';
 import { DB } from '../../db';
 import { QuotaExceededError, BatchLimitExceededError } from '../../errors';
 
@@ -93,9 +93,24 @@ describe('UsageService', () => {
       await expect(consumeJobs(mockApiKeyId, 1)).rejects.toThrow('TRANS_FAIL');
       expect(mockClient.query).toHaveBeenCalledWith('ROLLBACK');
     });
-  });
+    });
 
-  describe('getUsageSnapshot', () => {
+    describe('consumeJobsWithClient', () => {
+    test('should consume jobs using provided client', async () => {
+      mockClient.query.mockResolvedValueOnce({ rows: [mockUsageRow] }); // SELECT
+      mockClient.query.mockResolvedValueOnce({ rows: [] }); // UPDATE
+
+      const snapshot = await consumeJobsWithClient(mockClient, mockApiKeyId, 5);
+
+      expect(snapshot.monthlyUsage).toBe(15);
+      expect(mockClient.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE'), [mockApiKeyId, 15]);
+      // Client should not be released by the service
+      expect(mockClient.release).not.toHaveBeenCalled();
+    });
+    });
+
+    describe('getUsageSnapshot', () => {
+
     test('should return current usage without consuming', async () => {
       mockClient.query.mockResolvedValueOnce({ rows: [] }); // BEGIN
       mockClient.query.mockResolvedValueOnce({ rows: [mockUsageRow] }); // SELECT

--- a/src/services/usage.service.ts
+++ b/src/services/usage.service.ts
@@ -94,15 +94,11 @@ type ConsumeOptions = {
 };
 
 /**
- * Check quota and, if allowed, consume jobs atomically.
- *
- * This function:
- * - Resets monthly usage when quota_reset_at is in the past
- * - Ensures requestedJobs does not exceed tier max_batch_size (when enforced)
- * - Ensures monthly_usage + requestedJobs <= monthly_quota
- * - Increments monthly_usage within a transaction
+ * Check quota and, if allowed, consume jobs atomically using an existing client.
+ * Use this when you are already inside a transaction.
  */
-export async function consumeJobs(
+export async function consumeJobsWithClient(
+  client: typeof DB | { query: typeof DB.query },
   apiKeyId: number,
   requestedJobs: number,
   options: ConsumeOptions = {},
@@ -111,38 +107,48 @@ export async function consumeJobs(
     throw new Error('requestedJobs must be positive');
   }
 
+  const row = await loadUsageRowForUpdate(client, apiKeyId);
+  const tierConfig = getTierConfig(row.tier);
+
+  if (options.enforceBatchLimit && requestedJobs > tierConfig.maxBatchSize) {
+    throw new BatchLimitExceededError(`Batch size exceeds allowed tier limit of ${tierConfig.maxBatchSize}`);
+  }
+
+  const projectedUsage = row.monthly_usage + requestedJobs;
+  if (projectedUsage > row.monthly_quota) {
+    throw new QuotaExceededError('Monthly usage limit reached');
+  }
+
+  await client.query(
+    `UPDATE api_keys
+     SET monthly_usage = $2
+     WHERE id = $1`,
+    [row.id, projectedUsage],
+  );
+
+  const updatedRow: UsageRow = {
+    ...row,
+    monthly_usage: projectedUsage,
+  };
+
+  return buildSnapshot(updatedRow);
+}
+
+/**
+ * Check quota and, if allowed, consume jobs atomically.
+ */
+export async function consumeJobs(
+  apiKeyId: number,
+  requestedJobs: number,
+  options: ConsumeOptions = {},
+): Promise<UsageSnapshot> {
   const client = await DB.connect();
 
   try {
     await client.query('BEGIN');
-
-    const row = await loadUsageRowForUpdate(client, apiKeyId);
-    const tierConfig = getTierConfig(row.tier);
-
-    if (options.enforceBatchLimit && requestedJobs > tierConfig.maxBatchSize) {
-      throw new BatchLimitExceededError('Batch size exceeds allowed tier limit');
-    }
-
-    const projectedUsage = row.monthly_usage + requestedJobs;
-    if (projectedUsage > row.monthly_quota) {
-      throw new QuotaExceededError('Monthly usage limit reached');
-    }
-
-    await client.query(
-      `UPDATE api_keys
-       SET monthly_usage = $2
-       WHERE id = $1`,
-      [row.id, projectedUsage],
-    );
-
-    const updatedRow: UsageRow = {
-      ...row,
-      monthly_usage: projectedUsage,
-    };
-
+    const snapshot = await consumeJobsWithClient(client, apiKeyId, requestedJobs, options);
     await client.query('COMMIT');
-
-    return buildSnapshot(updatedRow);
+    return snapshot;
   } catch (error) {
     await client.query('ROLLBACK');
     throw error;


### PR DESCRIPTION
Prevent quota increment on the read-only endpoints /usage