### PR TITLE
feat: add Neon PostgreSQL support with environment-based SSL configuration

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,11 +1,23 @@
-import { Pool } from 'pg';
+import { Pool, PoolConfig } from 'pg';
 import fs from 'fs';
 import path from 'path';
-import { DATABASE_URL } from '../config';
+import { DATABASE_URL, IS_PRODUCTION } from '../config';
 
-export const DB = new Pool({
+/**
+ * Database connection pool configuration.
+ * Uses SSL in production for Neon compatibility.
+ */
+const poolConfig: PoolConfig = {
   connectionString: DATABASE_URL,
-});
+};
+
+if (IS_PRODUCTION) {
+  poolConfig.ssl = {
+    rejectUnauthorized: false,
+  };
+}
+
+export const DB = new Pool(poolConfig);
 
 /**
  * Initialize database and run migrations.
@@ -36,11 +48,11 @@ export async function initDB() {
     for (const file of files) {
       // Check if migration already applied
       const check = await DB.query('SELECT 1 FROM applied_migrations WHERE file_name = $1', [file]);
-      
+
       if (check.rows.length === 0) {
         const migrationPath = path.join(migrationsDir, file);
         const migration = fs.readFileSync(migrationPath, 'utf8');
-        
+
         await DB.query('BEGIN');
         try {
           await DB.query(migration);
@@ -63,12 +75,10 @@ export async function areMigrationsPending(): Promise<boolean> {
   const migrationsDir = path.join(__dirname, 'migrations');
   if (!fs.existsSync(migrationsDir)) return false;
 
-  const files = fs
-    .readdirSync(migrationsDir)
-    .filter((f) => f.endsWith('.sql'));
+  const files = fs.readdirSync(migrationsDir).filter((f) => f.endsWith('.sql'));
 
   const result = await DB.query<{ file_name: string }>('SELECT file_name FROM applied_migrations');
-  const appliedFiles = new Set(result.rows.map(r => r.file_name));
+  const appliedFiles = new Set(result.rows.map((r) => r.file_name));
 
-  return files.some(f => !appliedFiles.has(f));
+  return files.some((f) => !appliedFiles.has(f));
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,10 +4,7 @@ import { DB } from './db';
 import { initializeJobService } from './services/monitorJob.service';
 import { getActiveJobCount } from './utils/concurrencyGuard';
 import { markAsInitialized } from './routes/health.route';
-import {
-  initReconciliation,
-  reconcileConcurrencyState,
-} from './services/concurrencyReconciliation.service';
+import { initReconciliation, reconcileConcurrencyState } from './services/concurrencyReconciliation.service';
 import { performBackup } from './services/backup.service';
 import cron from 'node-cron';
 
@@ -26,8 +23,14 @@ const start = async () => {
     // 2. Database readiness check (EXPLICIT migrations)
     try {
       await DB.query('SELECT 1 FROM applied_migrations LIMIT 1');
-    } catch (err) {
-      app.log.error('DATABASE_NOT_INITIALIZED: Run npm run migrate before starting server.');
+    } catch (err: any) {
+      // Differentiate between "Table missing" and "Connection failed"
+      if (err.code === '42P01') {
+        // 42P01 is PostgreSQL code for "undefined_table"
+        app.log.error('DATABASE_NOT_INITIALIZED: Run npm run migrate before starting server.');
+      } else {
+        app.log.error({ err }, 'DATABASE_CONNECTION_ERROR: Could not connect to database.');
+      }
       process.exit(1);
     }
 


### PR DESCRIPTION
### Adds support for Neon PostgreSQL as the production database while maintaining compatibility with local PostgreSQL for development.

Changes include:

- DATABASE_URL-based connection configuration
- Conditional SSL support for Neon
- Environment-based database connection handling
- No changes to repository or service layers

This allows PolicyDiff to run locally with a standard PostgreSQL
instance while using Neon serverless PostgreSQL in production.