### PR TITLE
feat: implement API key regeneration with in-place key rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,34 @@ Requires `X-Provision-Secret: <token>` configured by the `PROVISION_SECRET` env 
 - Returns the key ONCE.
 - Tiers: `FREE`, `STARTER`, `PRO`. Default is `FREE`.
 
+### `POST /v1/internal/regenerate-key`
+
+Endpoint to regenerate an existing API key without creating a new record. This preserves usage history, quotas, and monitoring data.
+
+**X-Provision-Secret Header:**
+Requires `X-Provision-Secret: <token>`.
+
+**Example Request:**
+
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+**Example Response (200 OK):**
+
+```json
+{
+  "apiKey": "pd_live_new_key_...",
+  "warning": "Store this key securely. It will not be shown again."
+}
+```
+
+- Finds the active key by email and replaces its hash.
+- Sets the `rotated_at` timestamp.
+- Returns the new raw key ONCE.
+
 **Error Contract:**
 
 All API errors follow a standard format.

--- a/src/controllers/internal.controller.ts
+++ b/src/controllers/internal.controller.ts
@@ -1,5 +1,5 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
-import { provisionApiKey } from '../services/provisioning.service';
+import { provisionApiKey, regenerateApiKey } from '../services/provisioning.service';
 import { validateSnapshotDeterminism } from '../services/replayValidator.service';
 import { captureReplaySnapshot } from '../services/replaySnapshot.service';
 import { PROVISION_SECRET } from '../config';
@@ -54,6 +54,39 @@ export async function provisionHandler(request: FastifyRequest<{ Body: Provision
     apiKey: rawKey,
     warning: 'Store this key securely. It will not be shown again.',
   };
+}
+
+export async function regenerateKeyHandler(request: FastifyRequest<{ Body: { email: string } }>, reply: FastifyReply) {
+  const secret = request.headers['x-provision-secret'];
+  if (!secret || secret !== PROVISION_SECRET) {
+    throw new ProvisionSecretInvalidError();
+  }
+
+  const { email } = request.body;
+
+  if (!email || !EMAIL_REGEX.test(email)) {
+    throw new InvalidEmailError();
+  }
+
+  try {
+    const { rawKey } = await regenerateApiKey(email);
+
+    request.log.info({
+      event: 'api_key_regenerated',
+      email,
+    });
+
+    return {
+      apiKey: rawKey,
+      warning: 'Store this key securely. It will not be shown again.',
+    };
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === 'API_KEY_NOT_FOUND') {
+      reply.status(404).send({ error: 'NotFound', message: 'Active API key not found for this email' });
+      return;
+    }
+    throw err;
+  }
 }
 
 export async function replayHandler(request: FastifyRequest<{ Params: { snapshotId: string } }>, reply: FastifyReply) {

--- a/src/db/migrations/014_api_key_rotation.sql
+++ b/src/db/migrations/014_api_key_rotation.sql
@@ -1,0 +1,2 @@
+-- Add rotated_at timestamp to api_keys table for security auditing
+ALTER TABLE api_keys ADD COLUMN IF NOT EXISTS rotated_at TIMESTAMPTZ;

--- a/src/repositories/apiKey.repository.ts
+++ b/src/repositories/apiKey.repository.ts
@@ -15,6 +15,7 @@ function rowToApiKey(row: ApiKeyRow): ApiKey {
     environment: (row.environment as string) === 'live' ? 'prod' : (row.environment as ApiKeyEnvironment),
     isActive: row.is_active,
     createdAt: row.created_at,
+    rotatedAt: row.rotated_at,
     tier: row.tier,
     monthlyQuota: row.monthly_quota,
     monthlyUsage: row.monthly_usage,
@@ -29,7 +30,7 @@ function rowToApiKey(row: ApiKeyRow): ApiKey {
 export async function findApiKeyByHash(keyHash: string): Promise<ApiKey | null> {
   const result = await DB.query<ApiKeyRow>(
     `SELECT id, key_hash, name, email, environment, is_active,
-            created_at, tier, monthly_quota, monthly_usage, quota_reset_at
+            created_at, rotated_at, tier, monthly_quota, monthly_usage, quota_reset_at
      FROM api_keys
      WHERE key_hash = $1`,
     [keyHash],
@@ -88,7 +89,7 @@ export async function deactivateApiKey(keyId: number): Promise<void> {
 export async function findActiveByEmail(email: string): Promise<ApiKey | null> {
   const result = await DB.query<ApiKeyRow>(
     `SELECT id, key_hash, name, email, environment, is_active,
-            created_at, tier, monthly_quota, monthly_usage, quota_reset_at
+            created_at, rotated_at, tier, monthly_quota, monthly_usage, quota_reset_at
      FROM api_keys
      WHERE email = $1 AND is_active = TRUE`,
     [email],
@@ -102,8 +103,19 @@ export async function findActiveByEmail(email: string): Promise<ApiKey | null> {
 }
 
 /**
+ * Update the key hash for an existing record (regeneration)
+ */
+export async function updateApiKeyHash(apiKeyId: number, newHash: string): Promise<void> {
+  await DB.query(
+    `UPDATE api_keys
+     SET key_hash = $2, rotated_at = NOW()
+     WHERE id = $1`,
+    [apiKeyId, newHash],
+  );
+}
+
+/**
  * Count unique page_ids associated with an API key across all its monitor jobs.
- * This is used to enforce the tier-based maxUrls limit.
  */
 export async function countDistinctUrlsForKey(
   apiKeyId: number,
@@ -133,7 +145,7 @@ export async function insertProvisionedKey(
      )
      VALUES ($1, $2, $3, $4, $5, $6, 0, $7, TRUE)
      RETURNING id, key_hash, name, email, environment, is_active,
-               created_at, tier, monthly_quota, monthly_usage, quota_reset_at`,
+               created_at, rotated_at, tier, monthly_quota, monthly_usage, quota_reset_at`,
     [keyHash, input.name, input.email, input.environment, input.tier, input.monthlyQuota, quotaResetAt],
   );
 

--- a/src/routes/internal.route.ts
+++ b/src/routes/internal.route.ts
@@ -1,7 +1,12 @@
 import { FastifyInstance, FastifyRequest, FastifyReply } from 'fastify';
 import { getInternalMetrics } from '../repositories/metrics.repository';
 import { INTERNAL_METRICS_TOKEN } from '../config';
-import { provisionHandler, replayHandler, createSnapshotController } from '../controllers/internal.controller';
+import {
+  provisionHandler,
+  regenerateKeyHandler,
+  replayHandler,
+  createSnapshotController,
+} from '../controllers/internal.controller';
 import { recordAbuseEvent } from '../services/requestAbuse.service';
 
 /**
@@ -13,7 +18,7 @@ async function validateInternalToken(request: FastifyRequest, reply: FastifyRepl
   if (!token || token !== INTERNAL_METRICS_TOKEN) {
     request.log.warn({ request_ip: request.ip }, 'INVALID_INTERNAL_TOKEN_ATTEMPT');
     await recordAbuseEvent('INVALID_INTERNAL_TOKEN_ATTEMPT', null, request.ip);
-    
+
     reply.code(401).send({
       error: 'Unauthorized',
       message: 'Invalid or missing internal token',
@@ -47,6 +52,14 @@ export async function internalRoutes(fastify: FastifyInstance) {
    * Provisions a new API key.
    */
   fastify.post('/internal/provision', provisionHandler);
+
+  /**
+   * POST /v1/internal/regenerate-key
+   *
+   * Protected by X-Provision-Secret header.
+   * Regenerates an existing API key.
+   */
+  fastify.post('/internal/regenerate-key', regenerateKeyHandler);
 
   /**
    * POST /v1/internal/replay/:snapshotId

--- a/src/services/provisioning.service.ts
+++ b/src/services/provisioning.service.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto';
-import { findActiveByEmail, insertProvisionedKey } from '../repositories/apiKey.repository';
+import { findActiveByEmail, insertProvisionedKey, updateApiKeyHash } from '../repositories/apiKey.repository';
 import { getTierConfig } from '../config/tierConfig';
 import { ApiKeyEnvironment, CreateApiKeyInput } from '../types';
 import { ApiKeyAlreadyExistsError, InvalidEmailError } from '../errors';
@@ -37,6 +37,27 @@ export async function provisionApiKey(input: {
   };
 
   await insertProvisionedKey(keyHash, dbInput, quotaResetAt);
+
+  return { rawKey };
+}
+
+export async function regenerateApiKey(email: string): Promise<{ rawKey: string }> {
+  if (!email || !EMAIL_REGEX.test(email)) {
+    throw new InvalidEmailError();
+  }
+
+  const existingKey = await findActiveByEmail(email);
+  if (!existingKey) {
+    throw new Error('API_KEY_NOT_FOUND');
+  }
+
+  const rawBytes = crypto.randomBytes(32).toString('hex');
+  const prefix = existingKey.environment === 'dev' ? 'pd_dev_' : 'pd_live_';
+  const rawKey = `${prefix}${rawBytes}`;
+
+  const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
+
+  await updateApiKeyHash(existingKey.id, keyHash);
 
   return { rawKey };
 }

--- a/src/services/tests/provisioning.service.test.ts
+++ b/src/services/tests/provisioning.service.test.ts
@@ -1,4 +1,4 @@
-import { provisionApiKey } from '../provisioning.service';
+import { provisionApiKey, regenerateApiKey } from '../provisioning.service';
 import * as apiKeyRepository from '../../repositories/apiKey.repository';
 import { InvalidEmailError, ApiKeyAlreadyExistsError } from '../../errors';
 import crypto from 'crypto';
@@ -150,6 +150,50 @@ describe('ProvisioningService', () => {
       (apiKeyRepository.insertProvisionedKey as jest.Mock).mockRejectedValue(new Error('INSERT_FAILED'));
 
       await expect(provisionApiKey(mockInput)).rejects.toThrow('INSERT_FAILED');
+    });
+  });
+
+  describe('regenerateApiKey', () => {
+    const mockEmail = 'existing@example.com';
+    const mockApiKeyRecord = {
+      id: 123,
+      email: mockEmail,
+      environment: 'prod',
+      isActive: true,
+    };
+
+    test('should regenerate API key for active email', async () => {
+      (apiKeyRepository.findActiveByEmail as jest.Mock).mockResolvedValue(mockApiKeyRecord);
+      (apiKeyRepository.updateApiKeyHash as jest.Mock).mockResolvedValue(undefined);
+
+      const result = await regenerateApiKey(mockEmail);
+
+      expect(result.rawKey).toMatch(/^pd_live_[a-f0-9]{64}$/);
+      expect(apiKeyRepository.findActiveByEmail).toHaveBeenCalledWith(mockEmail);
+      
+      const rawKey = result.rawKey;
+      const expectedHash = crypto.createHash('sha256').update(rawKey).digest('hex');
+      expect(apiKeyRepository.updateApiKeyHash).toHaveBeenCalledWith(mockApiKeyRecord.id, expectedHash);
+    });
+
+    test('should use dev prefix if original key was dev', async () => {
+      (apiKeyRepository.findActiveByEmail as jest.Mock).mockResolvedValue({
+        ...mockApiKeyRecord,
+        environment: 'dev',
+      });
+
+      const result = await regenerateApiKey(mockEmail);
+      expect(result.rawKey).toMatch(/^pd_dev_/);
+    });
+
+    test('should throw error if email not found', async () => {
+      (apiKeyRepository.findActiveByEmail as jest.Mock).mockResolvedValue(null);
+
+      await expect(regenerateApiKey(mockEmail)).rejects.toThrow('API_KEY_NOT_FOUND');
+    });
+
+    test('should throw InvalidEmailError for malformed email', async () => {
+      await expect(regenerateApiKey('not-an-email')).rejects.toThrow(InvalidEmailError);
     });
   });
 });

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -12,6 +12,7 @@ export type ApiKey = {
   environment: ApiKeyEnvironment;
   isActive: boolean;
   createdAt: Date;
+  rotatedAt?: Date;
   tier: 'FREE' | 'STARTER' | 'PRO';
   monthlyQuota: number;
   monthlyUsage: number;
@@ -26,6 +27,7 @@ export type ApiKeyRow = {
   environment: ApiKeyEnvironment;
   is_active: boolean;
   created_at: Date;
+  rotated_at?: Date;
   tier: 'FREE' | 'STARTER' | 'PRO';
   monthly_quota: number;
   monthly_usage: number;


### PR DESCRIPTION
### Adds support for API key regeneration without creating new records.

The new endpoint `/v1/internal/regenerate-key` allows the system to rotate
an existing API key associated with a user email.

Key properties:

- The existing API key record is updated in place
- Usage, quota, and monitoring history remain unchanged
- Only the key hash is replaced
- The raw API key is returned once and must be delivered to the user securely

This feature enables recovery when users lose their API key and supports
future self-service key regeneration flows on the landing page.